### PR TITLE
scfinder: adding dynamic window length for envelope maxima

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 2022 ?
 
+* scfinder:
+
+  * Dynamic window length for envelope maxima.
+
 ## Release 2022 July 26 tag 4.9.2
 
 * libs/eewamps (included in sceewenv, scfinder): 

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -87,9 +87,9 @@
 						rupture (in km) is less than the default time window (in seconds) * 1.5. 
 						Otherwise the window length (in seconds) is computed as
 						maximum rupture length (in km) / 1.5, up to the maximum size of the 
-            envelope buffer as defined by envelopeBufferSize. A smaller value will 
-            reduce false detections caused by noise, but the value should be large enough
-            to account for station spacing and the number of trigger stations used by FinDer.
+						envelope buffer as defined by envelopeBufferSize. A smaller value will 
+						reduce false detections caused by noise, but the value should be large enough
+						to account for station spacing and the number of trigger stations used by FinDer.
 					</description>
 				</parameter>
 				<parameter name="scanInterval" type="double" default="0.1" unit="s">

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -74,21 +74,21 @@
 				<parameter name="envelopeBufferSize" type="double" default="120" unit="s">
 					<description>
 						Size of envelope buffer in seconds. This value should be set 
-            large enough for the longest anticipated rupture duration.
-            The envelope buffer is a ring buffer and FinDer receives a 
-            maximum from it based on the time window defined by envelopeDefaultBufLen. 
+						large enough for the longest anticipated rupture duration.
+						The envelope buffer is a ring buffer and FinDer receives a 
+						maximum from it based on the time window defined by envelopeDefaultBufLen. 
 					</description>
 				</parameter>
 				<parameter name="envelopeDefaultBufLen" type="double" default="120" unit="s">
 					<description>
-            Default window length (in seconds) of envelope buffer to consider when
-            passing maximum to FinDer. This default window length will be used 
-            when there are no active FinDer events, or the largest FinDer event
-            rupture (in km) is less than the default time window (in seconds) * 1.5. 
-            Otherwise the window length (in seconds) is computed as
-            maximum rupture length (in km) / 1.5, up to the maximum size of the 
-            envelope buffer as defined by envelopeBufferSize.
-          </description>
+						Default window length (in seconds) of envelope buffer to consider when
+						passing maximum to FinDer. This default window length will be used 
+						when there are no active FinDer events, or the largest FinDer event
+						rupture (in km) is less than the default time window (in seconds) * 1.5. 
+						Otherwise the window length (in seconds) is computed as
+						maximum rupture length (in km) / 1.5, up to the maximum size of the 
+						envelope buffer as defined by envelopeBufferSize.
+					</description>
 				</parameter>
 				<parameter name="scanInterval" type="double" default="0.1" unit="s">
 					<description>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -73,9 +73,22 @@
 				</parameter>
 				<parameter name="envelopeBufferSize" type="double" default="120" unit="s">
 					<description>
-						Size of envelope buffer in seconds. The envelope buffer is
-						a ring buffer and FinDer receives the maximum of this ring.
+						Size of envelope buffer in seconds. This value should be set 
+            large enough for the longest anticipated rupture duration.
+            The envelope buffer is a ring buffer and FinDer receives a 
+            maximum from it based on the time window defined by envelopeDefaultBufLen. 
 					</description>
+				</parameter>
+				<parameter name="envelopeDefaultBufLen" type="double" default="120" unit="s">
+					<description>
+            Default window length (in seconds) of envelope buffer to consider when
+            passing maximum to FinDer. This default window length will be used 
+            when there are no active FinDer events, or the largest FinDer event
+            rupture (in km) is less than the default time window (in seconds) * 1.5. 
+            Otherwise the window length (in seconds) is computed as
+            maximum rupture length (in km) / 1.5, up to the maximum size of the 
+            envelope buffer as defined by envelopeBufferSize.
+          </description>
 				</parameter>
 				<parameter name="scanInterval" type="double" default="0.1" unit="s">
 					<description>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -76,18 +76,20 @@
 						Size of envelope buffer in seconds. This value should be set 
 						large enough for the longest anticipated rupture duration.
 						The envelope buffer is a ring buffer and FinDer receives a 
-						maximum from it based on the time window defined by envelopeDefaultBufLen. 
+						maximum from it based on the time window defined by defaultFinDerEnvelopeLength. 
 					</description>
 				</parameter>
-				<parameter name="envelopeDefaultBufLen" type="double" default="120" unit="s">
+				<parameter name="defaultFinDerEnvelopeLength" type="double" default="60" unit="s">
 					<description>
-						Default window length (in seconds) of envelope buffer to consider when
+						Default window length (in seconds) of envelope buffer to search when
 						passing maximum to FinDer. This default window length will be used 
 						when there are no active FinDer events, or the largest FinDer event
 						rupture (in km) is less than the default time window (in seconds) * 1.5. 
 						Otherwise the window length (in seconds) is computed as
 						maximum rupture length (in km) / 1.5, up to the maximum size of the 
-						envelope buffer as defined by envelopeBufferSize.
+            envelope buffer as defined by envelopeBufferSize. A smaller value will 
+            reduce false detections caused by noise, but the value should be large enough
+            to account for station spacing and the number of trigger stations used by FinDer.
 					</description>
 				</parameter>
 				<parameter name="scanInterval" type="double" default="0.1" unit="s">

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -217,6 +217,8 @@ class App : public Client::StreamApplication {
 			_playbackMode = false;
 
 			_bufferLength = Core::TimeSpan(120,0);
+      _bufDefaultLen = Core::TimeSpan(120,0);
+      _bufVarLen = Core::TimeSpan(120,0);
 
 			// Default Finder call interval is 1s
 			_finderProcessCallInterval.set(1);
@@ -313,6 +315,12 @@ class App : public Client::StreamApplication {
 
 			try {
 				_bufferLength = configGetDouble("finder.envelopeBufferSize");
+			}
+			catch ( ... ) {}
+
+			try {
+				_bufDefaultLen = configGetDouble("finder.envelopeDefaultBufLen");
+        _bufVarLen = configGetDouble("finder.envelopeDefaultBufLen");
 			}
 			catch ( ... ) {}
 
@@ -553,7 +561,8 @@ class App : public Client::StreamApplication {
 			}
 
 			// The minimum time for a valid amplitude
-			Core::Time minAmplTime = _referenceTime - _bufferLength;
+			//Core::Time minAmplTime = _referenceTime - _bufferLength;
+			Core::Time minAmplTime = _referenceTime - _bufVarLen;
 
 			#if defined(LOG_AMPS)
 			std::cout << "+ " << id << "." << proc->waveformID().channelCode() << "   " << _referenceTime.iso() << "   " << minAmplTime.iso() << "   " << timestamp.iso() << "   " << value << std::endl;
@@ -703,6 +712,7 @@ class App : public Client::StreamApplication {
 
 			#ifdef USE_FINDER
 			Finder_List::iterator fit;
+      double maxRupLen = 0.;
 			for ( fit = _finderList.begin(); fit != _finderList.end(); /* incrementing below */) {
 				// some method for getting the timestamp associated with the data
 				// event_continue == false when we want to stop processing
@@ -712,6 +722,9 @@ class App : public Client::StreamApplication {
 				catch ( FiniteFault::Error &e ) {
 					SEISCOMP_ERROR("Exception from FinDer::process: %s", e.what());
 				}
+        if ((*fit)->get_rupture_length() > maxRupLen) {
+          maxRupLen = (*fit)->get_rupture_length();
+        }
 
 				if ( (*fit)->get_finder_flags().get_message() &&
 				    ((*fit)->get_finder_length_list().size() > 0) )
@@ -726,6 +739,20 @@ class App : public Client::StreamApplication {
 				else
 					++fit;
 			}
+      if (_finderList.size() == 0) {
+        if (_bufVarLen != _bufDefaultLen) {
+ 					SEISCOMP_DEBUG("Resetting data window to %ld", _bufDefaultLen.seconds());
+        }
+        _bufVarLen = _bufDefaultLen;
+      } else {
+        double rup2time = 1.5;
+        if (maxRupLen > _bufVarLen * rup2time) {
+          double tmp = maxRupLen / rup2time;
+          _bufVarLen = min((long)tmp, _bufferLength.seconds());
+ 					SEISCOMP_DEBUG("Increasing data window to %ld because of active FinDer event rupture length %.1f", 
+              _bufVarLen.seconds(), maxRupLen);
+       }
+      }
 			#else
 			std::cerr << "ProcessData" << std::endl;
 			#endif
@@ -1012,6 +1039,8 @@ class App : public Client::StreamApplication {
 		std::string                    _finderConfig;
 
 		Core::TimeSpan                 _bufferLength;
+		Core::TimeSpan                 _bufDefaultLen;
+		Core::TimeSpan                 _bufVarLen;
 
 		Processing::EEWAmps::Processor _eewProc;
 		CreationInfo                   _creationInfo;

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -217,8 +217,8 @@ class App : public Client::StreamApplication {
 			_playbackMode = false;
 
 			_bufferLength = Core::TimeSpan(120,0);
-      _bufDefaultLen = Core::TimeSpan(120,0);
-      _bufVarLen = Core::TimeSpan(120,0);
+			_bufDefaultLen = Core::TimeSpan(120,0);
+			_bufVarLen = Core::TimeSpan(120,0);
 
 			// Default Finder call interval is 1s
 			_finderProcessCallInterval.set(1);
@@ -320,7 +320,7 @@ class App : public Client::StreamApplication {
 
 			try {
 				_bufDefaultLen = configGetDouble("finder.envelopeDefaultBufLen");
-        _bufVarLen = configGetDouble("finder.envelopeDefaultBufLen");
+				_bufVarLen = configGetDouble("finder.envelopeDefaultBufLen");
 			}
 			catch ( ... ) {}
 
@@ -712,7 +712,7 @@ class App : public Client::StreamApplication {
 
 			#ifdef USE_FINDER
 			Finder_List::iterator fit;
-      double maxRupLen = 0.;
+			double maxRupLen = 0.;
 			for ( fit = _finderList.begin(); fit != _finderList.end(); /* incrementing below */) {
 				// some method for getting the timestamp associated with the data
 				// event_continue == false when we want to stop processing
@@ -722,9 +722,9 @@ class App : public Client::StreamApplication {
 				catch ( FiniteFault::Error &e ) {
 					SEISCOMP_ERROR("Exception from FinDer::process: %s", e.what());
 				}
-        if ((*fit)->get_rupture_length() > maxRupLen) {
-          maxRupLen = (*fit)->get_rupture_length();
-        }
+				if ((*fit)->get_rupture_length() > maxRupLen) {
+					maxRupLen = (*fit)->get_rupture_length();
+				}
 
 				if ( (*fit)->get_finder_flags().get_message() &&
 				    ((*fit)->get_finder_length_list().size() > 0) )
@@ -739,20 +739,20 @@ class App : public Client::StreamApplication {
 				else
 					++fit;
 			}
-      if (_finderList.size() == 0) {
-        if (_bufVarLen != _bufDefaultLen) {
- 					SEISCOMP_DEBUG("Resetting data window to %ld", _bufDefaultLen.seconds());
-        }
-        _bufVarLen = _bufDefaultLen;
-      } else {
-        double rup2time = 1.5;
-        if (maxRupLen > _bufVarLen * rup2time) {
-          double tmp = maxRupLen / rup2time;
-          _bufVarLen = min((long)tmp, _bufferLength.seconds());
- 					SEISCOMP_DEBUG("Increasing data window to %ld because of active FinDer event rupture length %.1f", 
-              _bufVarLen.seconds(), maxRupLen);
-       }
-      }
+			if (_finderList.size() == 0) {
+				if (_bufVarLen != _bufDefaultLen) {
+					SEISCOMP_DEBUG("Resetting data window to %ld", _bufDefaultLen.seconds());
+				}
+				_bufVarLen = _bufDefaultLen;
+			} else {
+				double rup2time = 1.5;
+				if (maxRupLen > _bufVarLen * rup2time) {
+					double tmp = maxRupLen / rup2time;
+					_bufVarLen = min((long)tmp, _bufferLength.seconds());
+					SEISCOMP_DEBUG("Increasing data window to %ld because of active FinDer event rupture length %.1f", 
+					  _bufVarLen.seconds(), maxRupLen);
+				}
+			}
 			#else
 			std::cerr << "ProcessData" << std::endl;
 			#endif

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -217,8 +217,8 @@ class App : public Client::StreamApplication {
 			_playbackMode = false;
 
 			_bufferLength = Core::TimeSpan(120,0);
-			_bufDefaultLen = Core::TimeSpan(120,0);
-			_bufVarLen = Core::TimeSpan(120,0);
+			_bufDefaultLen = Core::TimeSpan(60,0);
+			_bufVarLen = Core::TimeSpan(60,0);
 
 			// Default Finder call interval is 1s
 			_finderProcessCallInterval.set(1);

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -319,8 +319,8 @@ class App : public Client::StreamApplication {
 			catch ( ... ) {}
 
 			try {
-				_bufDefaultLen = configGetDouble("finder.envelopeDefaultBufLen");
-				_bufVarLen = configGetDouble("finder.envelopeDefaultBufLen");
+				_bufDefaultLen = configGetDouble("finder.defaultFinDerEnvelopeLength");
+				_bufVarLen = configGetDouble("finder.defaultFinDerEnvelopeLength");
 			}
 			catch ( ... ) {}
 


### PR DESCRIPTION
Added the option of using a dynamic time interval when selecting PGA maxima from the ring buffer to pass to FinDer. This allows use of a smaller time interval by default that is less likely to combine random noise spikes but allows for average station spacing. When there is an active FinDer event, the time window will be increased (up to a maximum of the total buffer length) based on the event rupture length/magnitude, which allows for the rupture duration.

Documentation for new configuration parameters added.

Testing done to verify window used to pass values to FinDer resizes and resets as expected, and total ring buffer length remains unchanged as expected. Docker build and run checked as per https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/discussions/5.