### PR TITLE
Get rid of obsolete compose1 function

### DIFF
--- a/libs/seiscomp/datamodel/vs/envelope.cpp
+++ b/libs/seiscomp/datamodel/vs/envelope.cpp
@@ -76,10 +76,9 @@ Envelope::Envelope(const std::string& publicID)
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 Envelope::~Envelope() {
-	std::for_each(_envelopeChannels.begin(), _envelopeChannels.end(),
-	              std::compose1(std::bind2nd(std::mem_fun(&EnvelopeChannel::setParent),
-	                                         (PublicObject*)NULL),
-	                            std::mem_fun_ref(&EnvelopeChannelPtr::get)));
+	for ( auto &envelopeChannel : _envelopeChannels ) {
+		envelopeChannel->setParent(nullptr);
+	}
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/libs/seiscomp/datamodel/vs/envelopechannel.cpp
+++ b/libs/seiscomp/datamodel/vs/envelopechannel.cpp
@@ -74,10 +74,9 @@ EnvelopeChannel::EnvelopeChannel(const std::string& publicID)
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 EnvelopeChannel::~EnvelopeChannel() {
-	std::for_each(_envelopeValues.begin(), _envelopeValues.end(),
-	              std::compose1(std::bind2nd(std::mem_fun(&EnvelopeValue::setParent),
-	                                         (PublicObject*)NULL),
-	                            std::mem_fun_ref(&EnvelopeValuePtr::get)));
+	for ( auto &envelopeValue : _envelopeValues ) {
+		envelopeValue->setParent(nullptr);
+	}
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/libs/seiscomp/datamodel/vs/vs.cpp
+++ b/libs/seiscomp/datamodel/vs/vs.cpp
@@ -62,10 +62,9 @@ VS::VS(const VS& other)
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 VS::~VS() {
-	std::for_each(_envelopes.begin(), _envelopes.end(),
-	              std::compose1(std::bind2nd(std::mem_fun(&Envelope::setParent),
-	                                         (PublicObject*)NULL),
-	                            std::mem_fun_ref(&EnvelopePtr::get)));
+	for ( auto &envelope : _envelopes ) {
+		envelope->setParent(nullptr);
+	}
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 


### PR DESCRIPTION
Due to an API change this change is necessary for further compilation.