### PR TITLE
[scfinder, sceewenv] skipDataOlderThan and maxDelay

### DIFF
--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -107,6 +107,22 @@
 					</description>
 				</parameter>
 			</group>
+			<group name="debug">
+				<parameter name="maxDelay" type="double" default="3" unit="s">
+					<description>
+						Sets the maximum absolute value of packet delay before issuing a warning. That 
+						parameter does not configure buffers as such but only a threshold (in seconds 
+						with fractional part) to warn the user that something is not real-time anymore. 
+						The default is 3s.
+					</description>
+				</parameter>
+				<parameter name="skipDataOlderThan" type="double" default="180" unit="s">
+					<description>
+						Sets the maximum absolute value of packet delay before skipping data packet. The 
+						default is 60s.
+					</description>
+				</parameter>
+			</group>
 		</configuration>
 		<command-line>
 			<group name="Generic">

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -342,6 +342,16 @@ class App : public Client::StreamApplication {
 			eewCfg.dumpRecords = commandline().hasOption("dump");
 
 			eewCfg.vsfndr.enable = true;
+			eewCfg.maxDelay = 3.0;
+			eewCfg.skipDataOlderThan = 180.0;
+			try {
+				eewCfg.maxDelay = configGetDouble("debug.maxDelay");
+			}
+			catch ( ... ) {}
+			try {
+				eewCfg.skipDataOlderThan = configGetDouble("debug.skipDataOlderThan");
+			}
+			catch ( ... ) {}
 
 			// Convert to all signal units
 			eewCfg.wantSignal[Processing::WaveformProcessor::MeterPerSecondSquared] = true;

--- a/libs/seiscomp/processing/eewamps/processor.cpp
+++ b/libs/seiscomp/processing/eewamps/processor.cpp
@@ -416,14 +416,18 @@ bool Processor::feed(const Seiscomp::Record *rec) {
 
 	try {
 		Core::TimeSpan delay = now - rec->endTime();
-		if ( fabs(delay) > Core::TimeSpan( _members->config.skipDataOlderThan ) ) {
-			SEISCOMP_WARNING("%s: max allowed delay exceeded (data skipped): %fs",
-			                 rec->streamID().c_str(), (double)delay);
-			return false;
+		if (  _members->config.skipDataOlderThan > Core::TimeSpan( -1.0 ) ) {
+			if ( fabs(delay) > _members->config.skipDataOlderThan ) {
+				SEISCOMP_WARNING("%s: max allowed delay exceeded (data skipped): %fs",
+								rec->streamID().c_str(), (double)delay);
+				return false;
+			}
 		}
-		if ( fabs(delay) > _members->config.maxDelay ) {
-			SEISCOMP_WARNING("%s: delay exceeded (data still used): %fs",
-			                 rec->streamID().c_str(), (double)delay);
+		if ( _members->config.maxDelay > Core::TimeSpan( -1.0 ) ) {
+			if ( fabs(delay) > _members->config.maxDelay ) {
+				SEISCOMP_WARNING("%s: delay exceeded (data still used): %fs",
+								rec->streamID().c_str(), (double)delay);
+			}
 		}
 	}
 	catch ( ... ) {


### PR DESCRIPTION
Hello!

In this PR: 
1. `scfinder` cannot be used for processing data since 60s old data are ignored by default since https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/commit/ae6414007e139b156891938491baeeb7eea33a1a. This PR provides the parameters `skipDataOlderThan` (and maxDelay) controling this are now available in `scfinder` in the same way than in `sceewenv`.
2.  The EEW envelope processor now support option `-1` for `skipDataOlderThan` and `maxDelay` in `scfinder` and `scewenv` in order to skip the tests on data delay.  E.g. to processed a data file using `scfinder --record-file <file> --playback`, one must setup `skipDataOlderThan=-1` in `scfinder.cfg`

@maboese @jenrandrews @Camilo-sismo : can you check is anything looks probleamtic to you?