### PR TITLE
Fix latency filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
   
   * Fix reading for VS30 grid
 
+* scfinder:
+
+  * New parameter `maxEnvelopeBufferDelay`, to skip any channel not updated recently enough for input to FinDer.
+
+* sceewenv:
+
+  * Removing envelope delay filter as proven to be problematic in  scfinder.
+
 ## Release 2023 June 19 tag 5.1.2
 
 * sceewlog:

--- a/apps/eew/sceewenv/descriptions/sceewenv.xml
+++ b/apps/eew/sceewenv/descriptions/sceewenv.xml
@@ -134,12 +134,6 @@
 							The default is 3s.
 						</description>
 					</parameter>
-					<parameter name="skipDataOlderThan" type="double" default="30" unit="s">
-						<description>
-							Sets the maximum absolute value of packet delay before skipping data packet. The 
-							default is 30s.
-						</description>
-					</parameter>
 				</group>
 			</group>
 		</configuration>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -106,6 +106,12 @@
 						This can cause a high CPU usage.
 					</description>
 				</parameter>
+				<parameter name="maxEnvelopeBufferDelay" type="double" default="15" unit="s">
+					<description>
+						Sets the maximum delay for the latest update of each envelope buffer before 
+						skipping the related station stream in FinDer PGA input data. The default is 15s.
+					</description>
+				</parameter>
 			</group>
 			<group name="debug">
 				<parameter name="maxDelay" type="double" default="3" unit="s">
@@ -114,12 +120,6 @@
 						parameter does not configure buffers as such but only a threshold (in seconds 
 						with fractional part) to warn the user that something is not real-time anymore. 
 						The default is 3s.
-					</description>
-				</parameter>
-				<parameter name="skipDataOlderThan" type="double" default="30" unit="s">
-					<description>
-						Sets the maximum absolute value of packet delay before skipping data packet. The 
-						default is 30s.
 					</description>
 				</parameter>
 			</group>

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -655,6 +655,16 @@ class App : public Client::StreamApplication {
 			#endif
 			for ( it = _locationLookup.begin(); it != _locationLookup.end(); ++it ) {
 				if ( !it->second->maxPGA.timestamp.valid() ) continue;
+				
+				/* The above code is checking if the timestamp of the last element in the `pgas` vector is within
+				the last 30 seconds. If the condition is true, the code will continue with the next iteration of
+				the loop. */
+				if ( ( it->second->pgas.back().timestamp.seconds() ) < ( _referenceTime.seconds() - 30 ) ) {
+					std::cout << "Station skipped \t PGA buffer starts (iso,s)\t PGA buffer end (iso,s)\t Reference time (iso,s)" << std::endl;
+					std::cout << it->first << "\t" << it->second->pgas.front().timestamp.iso() << "\t" << it->second->pgas.back().timestamp.iso() << "\t" << _referenceTime.iso() << std::endl;
+					std::cout << it->first << "\t" << it->second->pgas.front().timestamp.seconds() << "\t" << it->second->pgas.back().timestamp.seconds() <<  "\t" << _referenceTime.seconds() << std::endl;
+					continue;
+				}
 
 				_latestMaxPGAs.push_back(
 					PGA_Data(
@@ -663,7 +673,8 @@ class App : public Client::StreamApplication {
 						it->second->maxPGA.channel.c_str(),
 						it->second->meta->code().empty()?"--":it->second->meta->code().c_str(),
 						Coordinate(it->second->meta->latitude(), it->second->meta->longitude()),
-						it->second->maxPGA.value*100, it->second->maxPGA.timestamp
+						it->second->maxPGA.value*100, 
+						it->second->maxPGA.timestamp
 					)
 				);
 				#if defined(LOG_AMPS)

--- a/libs/seiscomp/processing/eewamps/processor.cpp
+++ b/libs/seiscomp/processing/eewamps/processor.cpp
@@ -41,10 +41,6 @@ struct Processor::Members {
 	Config                       config;  //!< Global configuration object
 	Router                       router;  //!< Record router
 	IO::RecordFilterInterfacePtr demuxer; //!< Record stream demultiplexer
-        Core::Time lastCall;
-        Core::TimeSpan totalCallTime;
-        unsigned numCalls;
-        Core::Time lastPrinted;
 };
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -108,7 +104,6 @@ void Processor::showConfig() const {
 	SEISCOMP_DEBUG("hor-buffer-size     : %fs", (double)_members->config.horizontalBufferSize);
 	SEISCOMP_DEBUG("hor-max-delay       : %fs", (double)_members->config.horizontalMaxDelay);
 	SEISCOMP_DEBUG("max-delay           : %fs", (double)_members->config.maxDelay);
-	SEISCOMP_DEBUG("max-allowed-delay   : %fs", (double)_members->config.skipDataOlderThan);
 	SEISCOMP_DEBUG("enable-acc          : %s", _members->config.wantSignal[WaveformProcessor::MeterPerSecondSquared] ? "yes":"no");
 	SEISCOMP_DEBUG("enable-vel          : %s", _members->config.wantSignal[WaveformProcessor::MeterPerSecond] ? "yes":"no");
 	SEISCOMP_DEBUG("enable-disp         : %s", _members->config.wantSignal[WaveformProcessor::Meter] ? "yes":"no");
@@ -216,7 +211,8 @@ bool Processor::init(const Seiscomp::Config::Config &conf,
 		return false;
 
 	// ----------------------------------------------------------------------
-
+	// Read black- and whitelists
+	// ----------------------------------------------------------------------
 	try {
 		std::vector<std::string> tokens = conf.getStrings(configPrefix + "streams.whitelist");
 		for ( size_t i = 0; i < tokens.size(); ++i )
@@ -262,10 +258,6 @@ bool Processor::init(const Seiscomp::Config::Config &conf,
 
 	try {
 		_members->config.maxDelay = conf.getDouble(configPrefix + "debug.maxDelay");
-	}
-	catch ( ... ) {}
-	try {
-		_members->config.skipDataOlderThan = conf.getDouble(configPrefix + "debug.skipDataOlderThan");
 	}
 	catch ( ... ) {}
 
@@ -334,7 +326,6 @@ bool Processor::init(const Seiscomp::Config::Config &conf,
 	_members->demuxer = new IO::RecordDemuxFilter(tpl);
 	_members->router.setConfig(&_members->config);
 	_members->router.setInventory(_inventory);
-	_members->numCalls = 0;
 
 	return true;
 }
@@ -394,20 +385,6 @@ bool Processor::subscribeToChannels(IO::RecordStream *rs,
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 bool Processor::feed(const Seiscomp::Record *rec) {
-
-	Core::Time now =  Core::Time::GMT() ;
-	_members->totalCallTime += now - _members->lastCall;
-	_members->lastCall = now;
-	_members->numCalls++;
-	if ((double)(now - _members->lastPrinted) > 60) {
-		SEISCOMP_INFO("Average call time %.6f for %d iterations", 
-                              ((double)_members->totalCallTime)/_members->numCalls,
-                              _members->numCalls);
-		_members->numCalls = 0;
-		_members->totalCallTime = Core::TimeSpan(0.0);
-		_members->lastPrinted = now;
-	}
-
 	if ( _members->demuxer == NULL )
 		return false;
 
@@ -415,19 +392,10 @@ bool Processor::feed(const Seiscomp::Record *rec) {
 		return false;
 
 	try {
-		Core::TimeSpan delay = now - rec->endTime();
-		if (  _members->config.skipDataOlderThan > Core::TimeSpan( -1.0 ) ) {
-			if ( fabs(delay) > _members->config.skipDataOlderThan ) {
-				SEISCOMP_WARNING("%s: max allowed delay exceeded (data skipped): %fs",
-								rec->streamID().c_str(), (double)delay);
-				return false;
-			}
-		}
-		if ( _members->config.maxDelay > Core::TimeSpan( -1.0 ) ) {
-			if ( fabs(delay) > _members->config.maxDelay ) {
-				SEISCOMP_WARNING("%s: delay exceeded (data still used): %fs",
-								rec->streamID().c_str(), (double)delay);
-			}
+		Core::TimeSpan delay = Core::Time::GMT() - rec->endTime();
+		if ( delay > _members->config.maxDelay ) {
+			SEISCOMP_WARNING("%s: max delay exceeded: %fs",
+			                 rec->streamID().c_str(), (double)delay);
 		}
 	}
 	catch ( ... ) {


### PR DESCRIPTION
The latency filter in **_sceewenv_** is now removed because it was incorrect, and it was properly re-implemented in _**scfinder**_ as an envelope buffer delay threshold. 

The default value is 15 s and it can be configured with parameter `finder.maxEnvelopeBufferDelay`.