### PR TITLE
Envelope filter corner frequency

### DIFF
--- a/apps/eew/sceewenv/descriptions/sceewenv.xml
+++ b/apps/eew/sceewenv/descriptions/sceewenv.xml
@@ -73,17 +73,22 @@
 					</parameter>
 					<parameter name="filterAcc" type="boolean" default="false">
 						<description>
-							Enable acceleration 3s lo-pass filter, default is false.
+							Enable acceleration filter, default is false.
 						</description>
 					</parameter>
 					<parameter name="filterVel" type="boolean" default="false">
 						<description>
-							Enable velocity 3s lo-pass filter, default is false.
+							Enable velocity filter, default is false.
 						</description>
 					</parameter>
 					<parameter name="filterDisp" type="boolean" default="true">
 						<description>
-							Enable displacement 3s lo-pass filter, default is true.
+							Enable displacement filter, default is true.
+						</description>
+					</parameter>
+					<parameter name="filterCornerFreq" type="double" unit="Hz" default="1/3">
+						<description>
+							Sets the corner frequency of the Butterworth (4 poles) high-pass filter, default is 1/3 Hz.
 						</description>
 					</parameter>
 				</group>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -122,6 +122,11 @@
 						The default is 3s.
 					</description>
 				</parameter>
+				<parameter name="filterCornerFreq" type="double" unit="Hz" default="1/3">
+					<description>
+						Sets the corner frequency of the Butterworth (4 poles) high-pass filter, default is 1/3 Hz.
+					</description>
+				</parameter>
 			</group>
 		</configuration>
 		<command-line>

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -356,6 +356,13 @@ class App : public Client::StreamApplication {
 			eewCfg.dumpRecords = commandline().hasOption("dump");
 
 			eewCfg.vsfndr.enable = true;
+
+			eewCfg.vsfndr.filterCornerFreq = 1.0/3.0;
+			try {
+				eewCfg.vsfndr.filterCornerFreq = configGetDouble("debug.filterCornerFreq");
+			}
+			catch ( ... ) {}
+
 			eewCfg.maxDelay = 3.0;
 			try {
 				eewCfg.maxDelay = configGetDouble("debug.maxDelay");

--- a/libs/seiscomp/processing/eewamps/config.cpp
+++ b/libs/seiscomp/processing/eewamps/config.cpp
@@ -78,6 +78,7 @@ Config::Config() {
 	vsfndr.filterAcc = false;
 	vsfndr.filterVel = false;
 	vsfndr.filterDisp = true;
+	vsfndr.filterCornerFreq = 1.0/3.0;
 
 	// ----------------------------------------------------------------------
 	//  Gutenberg configuration

--- a/libs/seiscomp/processing/eewamps/config.h
+++ b/libs/seiscomp/processing/eewamps/config.h
@@ -158,6 +158,9 @@ struct SC_LIBEEWAMPS_API Config {
 		//! Enable displacement 3s lo-pass filter, default is true.
 		bool filterDisp;
 
+		//! Sets high pass filter corner frequency, default is 1.0/3.0.
+		double filterCornerFreq;
+
 		typedef boost::function<void (const BaseProcessor*,
 		                              double value,
 		                              const Core::Time &timestamp,

--- a/libs/seiscomp/processing/eewamps/processor.cpp
+++ b/libs/seiscomp/processing/eewamps/processor.cpp
@@ -107,13 +107,14 @@ void Processor::showConfig() const {
 	SEISCOMP_DEBUG("enable-acc          : %s", _members->config.wantSignal[WaveformProcessor::MeterPerSecondSquared] ? "yes":"no");
 	SEISCOMP_DEBUG("enable-vel          : %s", _members->config.wantSignal[WaveformProcessor::MeterPerSecond] ? "yes":"no");
 	SEISCOMP_DEBUG("enable-disp         : %s", _members->config.wantSignal[WaveformProcessor::Meter] ? "yes":"no");
-	SEISCOMP_DEBUG("enable-vsfndre      : %s", _members->config.vsfndr.enable ? "yes":"no");
+	SEISCOMP_DEBUG("enable-vsfndr       : %s", _members->config.vsfndr.enable ? "yes":"no");
 	SEISCOMP_DEBUG("enable-gba          : %s", _members->config.gba.enable ? "yes":"no");
 	SEISCOMP_DEBUG("enable-omp          : %s", _members->config.omp.enable ? "yes":"no");
 	SEISCOMP_DEBUG("vs-envelope-interval: %fs", (double)_members->config.vsfndr.envelopeInterval);
 	SEISCOMP_DEBUG("vs-filter-acc       : %s", _members->config.vsfndr.filterAcc ? "yes":"no");
 	SEISCOMP_DEBUG("vs-filter-vel       : %s", _members->config.vsfndr.filterVel ? "yes":"no");
 	SEISCOMP_DEBUG("vs-filter-disp      : %s", _members->config.vsfndr.filterDisp ? "yes":"no");
+	SEISCOMP_DEBUG("vs-filter-corner-freq  : %fHz",(double)_members->config.vsfndr.filterCornerFreq);
 	SEISCOMP_DEBUG("gba-buffer-size     : %fs", (double)_members->config.gba.bufferSize);
 	SEISCOMP_DEBUG("gba-cutoff-time     : %fs", (double)_members->config.gba.cutOffTime);
 	SEISCOMP_DEBUG("gba-passbands       : %d", (int)_members->config.gba.passbands.size());
@@ -297,6 +298,11 @@ bool Processor::init(const Seiscomp::Config::Config &conf,
 
 	try {
 		_members->config.vsfndr.filterDisp = conf.getBool(configPrefix + "vsfndr.filterDisp");
+	}
+	catch ( ... ) {}
+	
+	try {
+		_members->config.vsfndr.filterCornerFreq = conf.getDouble(configPrefix + "vsfndr.filterCornerFreq");
 	}
 	catch ( ... ) {}
 

--- a/libs/seiscomp/processing/eewamps/processors/envelope.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/envelope.cpp
@@ -43,15 +43,15 @@ EnvelopeProcessor::EnvelopeProcessor(const Config *config, SignalUnit unit)
 	switch ( _unit ) {
 		case Meter:
 			if ( _config->vsfndr.filterDisp )
-				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, 1.0/3.0));
+				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, _config->vsfndr.filterCornerFreq));
 			break;
 		case MeterPerSecond:
 			if ( _config->vsfndr.filterVel )
-				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, 1.0/3.0));
+				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, _config->vsfndr.filterCornerFreq));
 			break;
 		case MeterPerSecondSquared:
 			if ( _config->vsfndr.filterAcc )
-				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, 1.0/3.0));
+				setFilter(new Math::Filtering::IIR::ButterworthHighpass<double>(4, _config->vsfndr.filterCornerFreq));
 			break;
 		default:
 			setStatus(IncompatibleUnit, 1);


### PR DESCRIPTION
Adds configuration for env. filter corner freq.:
- sceewenv: ``eewenv.vsfndr.filterCornerFreq``
- scfinder: ``debug.filterCornerFreq``

@jenrandrews @sceylan @maboese : 
It can be tested with the finder docker container:
```bash
docker exec -u 0 -it  finder bash 

cd /usr/local/src/seiscomp/src/base/
rm -r sed-addons
git pull --branch env-filt-configurable https://github.com/FMassin/SED-EEW-SeisComP-contributions.git sed-addons
cd  /usr/local/src/seiscomp/src/build/src/base/sed-addons
make install
exit

docker exec -u 0 -it  finder /etc/init.d/mysql start
docker exec -u sysop -it  finder bash 

seiscomp restart scmaster
scfinder --dump-config  --debug
echo "debug.filterCornerFreq = 0.1" >> ~/.seiscomp/scfinder.cfg
scfinder --dump-config  --debug
echo vs-filter-corner-freq  should now be 0.100000Hz

sceewenv --dump-config --debug
echo "eewenv.vsfndr.filterCornerFreq = 0.1" >> ~/.seiscomp/sceewenv.cfg
sceewenv --dump-config --debug
echo vs-filter-corner-freq  should now be 0.100000Hz
```

Please test with your data and I will merge afterwards:
```bash
sceewenv --debug  -I <miniseed file> --test --dump > mseed
scfinder --debug  -I <miniseed file> --playback --test
```
