### PR TITLE
Fix all seiscomp3 api deps

### DIFF
--- a/apps/eew/sceewenv/main.cpp
+++ b/apps/eew/sceewenv/main.cpp
@@ -13,8 +13,8 @@
  *                                                                            *
  *   -----------------------------------------------------------------------  *
  *                                                                            *
- *   SeisComP3 EEW envelope modules that generates envelope amplitudes        *
- *   with libseiscomp3_eewamps and sends them as data messages to the         *
+ *   SeisComP EEW envelope modules that generates envelope amplitudes        *
+ *   with libseiscomp_eewamps and sends them as data messages to the         *
  *   messaging bus.                                                           *
  *                                                                            *
  *   -----------------------------------------------------------------------  *
@@ -26,12 +26,12 @@
 
 #define SEISCOMP_COMPONENT EEWENV
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/core/datamessage.h>
-#include <seiscomp3/client/streamapplication.h>
-#include <seiscomp3/client/inventory.h>
-#include <seiscomp3/io/records/mseedrecord.h>
-#include <seiscomp3/io/archive/xmlarchive.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/core/datamessage.h>
+#include <seiscomp/client/streamapplication.h>
+#include <seiscomp/client/inventory.h>
+#include <seiscomp/io/records/mseedrecord.h>
+#include <seiscomp/io/archive/xmlarchive.h>
 #include <seiscomp/processing/eewamps/processor.h>
 
 // This is required as datamodel/vs now resides in contrib-sed

--- a/apps/eew/sceewlog/descriptions/sceewlog.xml
+++ b/apps/eew/sceewlog/descriptions/sceewlog.xml
@@ -124,7 +124,7 @@
 					Time in seconds that events and the related objects are buffered.
 					</description>
 				</parameter>
-				<parameter name="directory" type="dir" default="~/.seiscomp3/log/EEW_reports">
+				<parameter name="directory" type="dir" default="~/.seiscomp/log/EEW_reports">
 					<description>
 					Directory to save reports to.
 					</description>

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -13,7 +13,7 @@
  *                                                                            *
  *   -----------------------------------------------------------------------  *
  *                                                                            *
- *   SeisComP3 wrapper for the FinDer algorithm using libFinder written by    *
+ *   SeisComP wrapper for the FinDer algorithm using libFinder written by    *
  *   Deborah E. Smith (deborahsmith@usgs.gov) and                             *
  *   Maren Böse, ETH, (maren.boese@erdw.ethz.ch).                             *
  *                                                                            *
@@ -31,15 +31,15 @@
 
 #define SEISCOMP_COMPONENT SCFINDER
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/logging/output.h>
-#include <seiscomp3/core/version.h>
-#include <seiscomp3/client/streamapplication.h>
-#include <seiscomp3/client/inventory.h>
-#include <seiscomp3/client/queue.h>
-#include <seiscomp3/datamodel/eventparameters.h>
-#include <seiscomp3/datamodel/origin.h>
-#include <seiscomp3/datamodel/magnitude.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/logging/output.h>
+#include <seiscomp/core/version.h>
+#include <seiscomp/client/streamapplication.h>
+#include <seiscomp/client/inventory.h>
+#include <seiscomp/client/queue.h>
+#include <seiscomp/datamodel/eventparameters.h>
+#include <seiscomp/datamodel/origin.h>
+#include <seiscomp/datamodel/magnitude.h>
 
 #if SC_API_VERSION < SC_API_VERSION_CHECK(14,0,0)
     #include <seiscomp3/datamodel/strongmotion/strongmotionparameters_package.h>
@@ -48,9 +48,9 @@
 #endif
 
 
-#include <seiscomp3/io/archive/xmlarchive.h>
+#include <seiscomp/io/archive/xmlarchive.h>
 #include <seiscomp/processing/eewamps/processor.h>
-#include <seiscomp3/math/geo.h>
+#include <seiscomp/math/geo.h>
 #include <functional>
 
 #include "finder.h"

--- a/apps/eew/scfinder/utils/makeFinDerPlot.py
+++ b/apps/eew/scfinder/utils/makeFinDerPlot.py
@@ -947,7 +947,7 @@ def runSeisComp(scevid = None):
                 UTCDateTime.now().strftime('%y%m%dT%H%M%S'), level=logging.INFO)
     logging.info('Running script for seiscomp eventID %s'%evid)
 
-    # FinDer solutions from seiscomp3 db
+    # FinDer solutions from seiscomp db
     len_xml = 0
     num_fdsols = 0
     bPreferredOnly = True
@@ -1041,7 +1041,7 @@ if __name__ == '__main__':
     if sys.argv[1] == '-h':
         print('\n\n\nScript for plotting FinDer solutions, it has two modes:\n \
 * run from the command line with arguments: -log <FinDer library log file> -ddir <FinDer directory containing data_ files>\n \
-* run from command line with a SeisComp3 event ID.\n\n \
+* run from command line with a SeisComP event ID.\n\n \
 Note that for the latter it requires scxmldump to be configured.\n\n\n')
         sys.exit()
     if len(sys.argv) == 2 and '-log' not in sys.argv:

--- a/doc/apps/sceewlog.rst
+++ b/doc/apps/sceewlog.rst
@@ -109,7 +109,7 @@ parameters will be evaluated globally.
 
 .. code-block:: sh
 
-   RegFilters.bnaFile = /opt/seiscomp3/share/sceewlog/closedpolygons.bna
+   RegFilters.bnaFile = /opt/seiscomp/share/sceewlog/closedpolygons.bna
    
 Then profile names have to be set. Two profile examples are provided below.
 

--- a/libs/seiscomp/processing/eewamps/baseprocessor.cpp
+++ b/libs/seiscomp/processing/eewamps/baseprocessor.cpp
@@ -19,8 +19,8 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/io/records/mseedrecord.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/io/records/mseedrecord.h>
 
 #include "baseprocessor.h"
 #include "config.h"

--- a/libs/seiscomp/processing/eewamps/baseprocessor.h
+++ b/libs/seiscomp/processing/eewamps/baseprocessor.h
@@ -20,8 +20,8 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_BASEPROCESSOR_H__
 
 
-#include <seiscomp3/datamodel/waveformstreamid.h>
-#include <seiscomp3/processing/waveformprocessor.h>
+#include <seiscomp/datamodel/waveformstreamid.h>
+#include <seiscomp/processing/waveformprocessor.h>
 #include <seiscomp/processing/eewamps/api.h>
 
 

--- a/libs/seiscomp/processing/eewamps/config.h
+++ b/libs/seiscomp/processing/eewamps/config.h
@@ -21,7 +21,7 @@
 
 
 #include <seiscomp/processing/eewamps/api.h>
-#include <seiscomp3/processing/waveformprocessor.h>
+#include <seiscomp/processing/waveformprocessor.h>
 #include <boost/function.hpp>
 
 #include "baseprocessor.h"

--- a/libs/seiscomp/processing/eewamps/filter/diffcentral.h
+++ b/libs/seiscomp/processing/eewamps/filter/diffcentral.h
@@ -21,7 +21,7 @@
 
 
 #include <seiscomp/processing/eewamps/api.h>
-#include <seiscomp3/math/filter.h>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp {

--- a/libs/seiscomp/processing/eewamps/filter/taup.h
+++ b/libs/seiscomp/processing/eewamps/filter/taup.h
@@ -21,7 +21,7 @@
 
 
 #include <seiscomp/processing/eewamps/api.h>
-#include <seiscomp3/math/filter.h>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp {

--- a/libs/seiscomp/processing/eewamps/preprocessor.cpp
+++ b/libs/seiscomp/processing/eewamps/preprocessor.cpp
@@ -19,13 +19,13 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/processing/operator/ncomps.h>
-#include <seiscomp3/io/records/mseedrecord.h>
-#include <seiscomp3/io/recordfilter/demux.h>
-#include <seiscomp3/io/recordfilter/iirfilter.h>
-#include <seiscomp3/math/filter/iirintegrate.h>
-#include <seiscomp3/math/filter/chainfilter.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/processing/operator/ncomps.h>
+#include <seiscomp/io/records/mseedrecord.h>
+#include <seiscomp/io/recordfilter/demux.h>
+#include <seiscomp/io/recordfilter/iirfilter.h>
+#include <seiscomp/math/filter/iirintegrate.h>
+#include <seiscomp/math/filter/chainfilter.h>
 
 #include "filter/diffcentral.h"
 #include "processors/envelope.h"

--- a/libs/seiscomp/processing/eewamps/preprocessor.h
+++ b/libs/seiscomp/processing/eewamps/preprocessor.h
@@ -20,10 +20,10 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_PREPROCESSOR_H__
 
 
-#include <seiscomp3/datamodel/waveformstreamid.h>
-#include <seiscomp3/processing/waveformprocessor.h>
+#include <seiscomp/datamodel/waveformstreamid.h>
+#include <seiscomp/processing/waveformprocessor.h>
 #include <seiscomp/processing/eewamps/api.h>
-#include <seiscomp3/io/recordfilter.h>
+#include <seiscomp/io/recordfilter.h>
 #include <vector>
 
 #include "baseprocessor.h"

--- a/libs/seiscomp/processing/eewamps/processor.cpp
+++ b/libs/seiscomp/processing/eewamps/processor.cpp
@@ -19,8 +19,8 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/io/recordfilter/demux.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/io/recordfilter/demux.h>
 
 #include "processor.h"
 #include "router.h"

--- a/libs/seiscomp/processing/eewamps/processor.h
+++ b/libs/seiscomp/processing/eewamps/processor.h
@@ -20,9 +20,9 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_PROCESSOR_H__
 
 
-#include <seiscomp3/config/config.h>
-#include <seiscomp3/io/recordstream.h>
-#include <seiscomp3/utils/stringfirewall.h>
+#include <seiscomp/config/config.h>
+#include <seiscomp/io/recordstream.h>
+#include <seiscomp/utils/stringfirewall.h>
 
 #include "config.h"
 

--- a/libs/seiscomp/processing/eewamps/processors/envelope.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/envelope.cpp
@@ -19,9 +19,9 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/math/filter/butterworth.h>
-#include <seiscomp3/math/mean.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/math/filter/butterworth.h>
+#include <seiscomp/math/mean.h>
 
 #include "envelope.h"
 #include "../config.h"

--- a/libs/seiscomp/processing/eewamps/processors/gba.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/gba.cpp
@@ -19,9 +19,9 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/math/filter/butterworth.h>
-#include <seiscomp3/datamodel/pick.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/math/filter/butterworth.h>
+#include <seiscomp/datamodel/pick.h>
 
 #include "gba.h"
 #include "../config.h"

--- a/libs/seiscomp/processing/eewamps/processors/gba.h
+++ b/libs/seiscomp/processing/eewamps/processors/gba.h
@@ -20,7 +20,7 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_GBA_H__
 
 
-#include <seiscomp3/core/recordsequence.h>
+#include <seiscomp/core/recordsequence.h>
 #include "../baseprocessor.h"
 
 

--- a/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
@@ -19,9 +19,9 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/datamodel/pick.h>
-#include <seiscomp3/io/records/mseedrecord.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/datamodel/pick.h>
+#include <seiscomp/io/records/mseedrecord.h>
 
 #include "onsitemag.h"
 #include "../config.h"

--- a/libs/seiscomp/processing/eewamps/processors/onsitemag.h
+++ b/libs/seiscomp/processing/eewamps/processors/onsitemag.h
@@ -20,9 +20,9 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_ONSITEMAG_H__
 
 
-#include <seiscomp3/core/recordsequence.h>
-#include <seiscomp3/math/filter/butterworth.h>
-#include <seiscomp3/math/filter/iirintegrate.h>
+#include <seiscomp/core/recordsequence.h>
+#include <seiscomp/math/filter/butterworth.h>
+#include <seiscomp/math/filter/iirintegrate.h>
 #include "../baseprocessor.h"
 #include "../filter/taup.h"
 

--- a/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
+++ b/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
@@ -19,11 +19,11 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/core/typedarray.h>
-#include <seiscomp3/core/genericrecord.h>
-#include <seiscomp3/core/exceptions.h>
-#include <seiscomp3/datamodel/utils.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/core/typedarray.h>
+#include <seiscomp/core/genericrecord.h>
+#include <seiscomp/core/exceptions.h>
+#include <seiscomp/datamodel/utils.h>
 
 #include "gainandbaselinecorrection.h"
 

--- a/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.h
+++ b/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.h
@@ -21,11 +21,11 @@
 
 
 #include <seiscomp/processing/eewamps/api.h>
-#include <seiscomp3/datamodel/inventory.h>
-#include <seiscomp3/io/recordfilter.h>
-#include <seiscomp3/math/filter/average.h>
-#include <seiscomp3/math/filter/taper.h>
-#include <seiscomp3/math/filter/butterworth.h>
+#include <seiscomp/datamodel/inventory.h>
+#include <seiscomp/io/recordfilter.h>
+#include <seiscomp/math/filter/average.h>
+#include <seiscomp/math/filter/taper.h>
+#include <seiscomp/math/filter/butterworth.h>
 
 
 #define BASELINE_CORRECTION_WITH_TAPER

--- a/libs/seiscomp/processing/eewamps/router.cpp
+++ b/libs/seiscomp/processing/eewamps/router.cpp
@@ -19,9 +19,9 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/datamodel/pick.h>
-#include <seiscomp3/datamodel/utils.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/datamodel/pick.h>
+#include <seiscomp/datamodel/utils.h>
 
 #include "preprocessor.h"
 #include "router.h"

--- a/libs/seiscomp/processing/eewamps/router.h
+++ b/libs/seiscomp/processing/eewamps/router.h
@@ -20,7 +20,7 @@
 #define __SEISCOMP_PROCESSING_EEWAMPS_ROUTER_H__
 
 
-#include <seiscomp3/datamodel/inventory.h>
+#include <seiscomp/datamodel/inventory.h>
 #include <map>
 #include <string>
 

--- a/test/eewamps/testgba.cpp
+++ b/test/eewamps/testgba.cpp
@@ -1,9 +1,9 @@
 #define SEISCOMP_COMPONENT TEST
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/client/streamapplication.h>
-#include <seiscomp3/client/inventory.h>
-#include <seiscomp3/io/records/mseedrecord.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/client/streamapplication.h>
+#include <seiscomp/client/inventory.h>
+#include <seiscomp/io/records/mseedrecord.h>
 #include <seiscomp/processing/eewamps/processor.h>
 #include <string>
 #include <functional>

--- a/test/eewamps/testprocs.cpp
+++ b/test/eewamps/testprocs.cpp
@@ -28,10 +28,10 @@
 
 #define SEISCOMP_COMPONENT TEST
 
-#include <seiscomp3/logging/log.h>
-#include <seiscomp3/client/streamapplication.h>
-#include <seiscomp3/client/inventory.h>
-#include <seiscomp3/io/records/mseedrecord.h>
+#include <seiscomp/logging/log.h>
+#include <seiscomp/client/streamapplication.h>
+#include <seiscomp/client/inventory.h>
+#include <seiscomp/io/records/mseedrecord.h>
 #include <seiscomp/processing/eewamps/processor.h>
 #include <string>
 #include <functional>


### PR DESCRIPTION
SeisComP 6.0.0 drops SeisComP3 API support. This PR fixes all remaining seiscomp3 C++ dependencies, i.e., C++ includes like
```c++
#include <seiscomp3/core/datetime.h>
```
are replaced by:
```c++
#include <seiscomp/core/datetime.h>
```
> Source: https://data.gempa.de/packages/Public/seiscomp/CHANGELOG

Fixing xml conversion stylesheets (e.g., apps/eew/sceewlog/config/sc3ml_0.15__quakeml_1.2-RT_eewd.xsl) remains to be done.
 
Moving the envelope library has already been done in https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/commit/a32642c23797c507a144ddfdf12fbdfa8f634f18

The required changes for Python have already been made since https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/commit/9564ed22bdf6c842c497c4e6f1df7f208522e6c7

