### PR TITLE
Avoid issue with converting X large data delay to int

### DIFF
--- a/libs/seiscomp/processing/eewamps/processors/envelope.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/envelope.cpp
@@ -26,6 +26,7 @@
 #include "envelope.h"
 #include "../config.h"
 
+#include <seiscomp/core/exceptions.h>
 
 namespace Seiscomp {
 namespace Processing {
@@ -150,8 +151,20 @@ void EnvelopeProcessor::process(const Record *rec, const DoubleArray &data) {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 void EnvelopeProcessor::setupTimeWindow(const Core::Time &ref) {
 	if ( _config->vsfndr.envelopeInterval.seconds() > 0 ) {
-		double r = floor(((double)ref / (double)_config->vsfndr.envelopeInterval));
-		_currentStartTime = r * _config->vsfndr.envelopeInterval;
+
+				
+		try {
+			double r = floor(((double)ref / (double)_config->vsfndr.envelopeInterval));
+			_currentStartTime = r * _config->vsfndr.envelopeInterval;
+		}
+		catch ( const Core::OverflowException& ) { 
+			std::cout << "Record start time (" << ref.iso().c_str() << ") cannot be converted to double and TimeWindow unchanged" << std::endl;
+		}
+		catch ( const std::exception &e ) {
+			SEISCOMP_WARNING("%s", e.what());
+			std::cout << "Unknown issue:" << e.what().c_str() << std::endl;
+
+		}
 
 		// Fix for possible rounding errors
 		if ( ref.microseconds() == 0 )


### PR DESCRIPTION
This is adding a catch statement in the envelope buffer time limit update method in order to avoid a crash in case the delay between the current time and record start time cannot be converted implicitly to an integer, which seems to happen when the delays reach enormous values (over 1 billion second).

This requires to be heavily tested before integration.