### PR TITLE
scfinder: add finder plane values to strong motion db

### DIFF
--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -948,6 +948,28 @@ class App : public Client::StreamApplication {
 				mag->add(comment.get());
 			}
 
+      {
+        RealQuantity ruptureWidth;
+        ruptureWidth.setValue(finder->get_rupture_width());
+        smRupture->setWidth(ruptureWidth);
+      }
+
+      {
+        string faultgeom = "POLYGON Z ((";
+        for (size_t i = 0; i < finder->get_finder_rupture_list().size(); i++) {
+          faultgeom += Core::toString(finder->get_finder_rupture_list()[i].get_lon());
+          faultgeom += " ";
+          faultgeom += Core::toString(finder->get_finder_rupture_list()[i].get_lat());
+          faultgeom += " ";
+          faultgeom += Core::toString(finder->get_finder_rupture_list()[i].get_depth());
+          if (i < finder->get_finder_rupture_list().size()-1) {
+            faultgeom += ", ";
+          }
+        }
+        faultgeom += "))";
+        smRupture->setRuptureGeometryWKT(faultgeom);
+      }
+
 #endif
 #if SC_API_VERSION >= SC_API_VERSION_CHECK(11,1,0)
 			{


### PR DESCRIPTION
Adding the fault rupture parameters into the strong motion database, both width and vertices.
The vertices are defined in 3D giving polygons like:
POLYGON Z ((174.4268172 -41.38235537 0, 174.4268172 -41.38235537 20, 172.3252084 -43.23986463 20, 172.3252084 -43.23986463 0, 174.4268172 -41.38235537 0))
The polygon is closed and vertices are (x y z) so (lon lat depth).