### PR TITLE
[sceewlog] Send email only if alert is raised (configurable)

### DIFF
--- a/apps/eew/sceewlog/config/sceewlog.cfg
+++ b/apps/eew/sceewlog/config/sceewlog.cfg
@@ -46,6 +46,9 @@ email.recipients=email1@provider1.com, email2@provider2.com
 # Only send a notification email if the magnitude threshold is exceeded.
 email.magThresh = 0.0
 
+# Only send a notification email if an alert was sent (activeMQ, FCM, or script).
+email.sendForAlertOnly = false
+
 # Save reports to disk.
 report.activate=true
 

--- a/apps/eew/sceewlog/descriptions/sceewlog.xml
+++ b/apps/eew/sceewlog/descriptions/sceewlog.xml
@@ -112,6 +112,11 @@
 					Only send a notification email if the magnitude threshold is exceeded.
 					</description>
 				</parameter>
+				<parameter name="sendForAlertOnly" type="boolean" default="false">
+					<description>
+					Only send a notification email if an alert was sent (activeMQ, FCM, or script).
+					</description>
+				</parameter>
 			</group>
 			<group name="report">
 				<parameter name="activate" type="boolean" default="true">

--- a/apps/eew/sceewlog/sceewlog.py
+++ b/apps/eew/sceewlog/sceewlog.py
@@ -66,7 +66,7 @@ class Listener(seiscomp.client.Application):
         self.email_sender = None
         self.email_recipients = None
         self.email_subject = None
-        self.email_sendForAlertOnly = True
+        self.email_sendForAlertOnly = False
         self.username = None
         self.password = None
         self.auth = False


### PR DESCRIPTION
This allows `sceewlog` to be configured to send the full EEW solution report by email only when the event included a magnitude that passed all configured thresholds including profiles if any.

This is made via switch `email.sendForAlertOnly = true` (set to `false` by default for backward compatibility).

As a test, I configured 2 separate instances of `sceewlog`: one reference sending all emails with the subject "EEW / SED ..", and another test instance sending emails only for events with alert-compliant magnitudes with the subject "TEST-EEW /SED..". The result below shows that only the event with a certain magnitude was sent by the test instance, while all were sent with the reference one.
![Screenshot 2024-08-13 at 11 50 49](https://github.com/user-attachments/assets/10d6e64f-34f8-4030-8352-71654abbde55)

@billyburgoa, @sceylan , @maboese & @jfclinton: please confirm that this looks correct from your point of view (code and architects respectively) so I can merge.