### PR TITLE
[scfinder] Add clipping handling to PGA processing

### DIFF
--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -8,7 +8,7 @@
 		<configuration>
 			<parameter name="saturationThreshold" type="double" default="80" unit="percent">
 				<description>
-					Saturation threshold in percent of 2**31 of raw values (COUNTS).
+					Saturation threshold in percent of 2**23 of raw values (COUNTS).
 				</description>
 			</parameter>
 			<parameter name="baselineCorrectionBuffer" type="double" default="60" unit="s">

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -121,7 +121,8 @@
 				<parameter name="preferredGainUnits" type="string" default="M/S**2">
 					<description>
 						Defines the preferred data gain units in case envelopes are provided by several 
-						different instruments from the same location code. Default is "M/S**2".
+						different instruments from the same location code. Default is "M/S**2". Set ""
+						(empty) to disable prevailing.
 					</description>
 				</parameter>
 			</group>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -114,7 +114,7 @@
 				</parameter>
 				<parameter name="clipTimeout" type="double" default="30" unit="s">
 					<description>
-						Define the delay following a clipped record that a stream is not used 
+						Defines the delay following a clipped record that a stream is not used 
 						in FinDer. Default is 30s.
 					</description>
 				</parameter>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -112,6 +112,12 @@
 						skipping the related station stream in FinDer PGA input data. The default is 15s.
 					</description>
 				</parameter>
+				<parameter name="clipTimeout" type="double" default="30" unit="s">
+					<description>
+						Define the delay following a clipped record that a stream is not used 
+						in FinDer. Default is 30s.
+					</description>
+				</parameter>
 			</group>
 			<group name="debug">
 				<parameter name="maxDelay" type="double" default="3" unit="s">

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -118,6 +118,12 @@
 						in FinDer. Default is 30s.
 					</description>
 				</parameter>
+				<parameter name="preferredGainUnits" type="string" default="M/S**2">
+					<description>
+						Defines the preferred data gain units in case envelopes are provided by several 
+						different instruments from the same location code. Default is "M/S**2".
+					</description>
+				</parameter>
 			</group>
 			<group name="debug">
 				<parameter name="maxDelay" type="double" default="3" unit="s">

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -1212,6 +1212,7 @@ bool App::Buddy::updateMaximum(const Core::Time &minTime, const std::string pref
 		for ( it = pgas.begin(); it != pgas.end(); ++it ) {
 
 			// Skip if value is smaller or outdated.
+			if ( it->timestamp < minTime ) continue;
 			if ( maxPGA.timestamp.valid() && it->value < maxPGA.value ) continue;			
 
 			// Skip if gain unit does not match the configured prevailing 
@@ -1220,11 +1221,11 @@ bool App::Buddy::updateMaximum(const Core::Time &minTime, const std::string pref
 			     && ( strcmp( lastMaximum.gainunit.c_str(), preferredGainUnits.c_str() ) == 0 ) 
 				 && ( strcmp( it->gainunit.c_str(), preferredGainUnits.c_str() ) != 0 ) ) {
 
-					SEISCOMP_DEBUG("%s [%s] rules over %s [%s]",
-									lastMaximum.channel.c_str(),
-									lastMaximum.gainunit.c_str(),
-									it->channel.c_str(),
-									it->gainunit.c_str() );
+					// SEISCOMP_DEBUG("%s [%s] rules over %s [%s]",
+					// 				lastMaximum.channel.c_str(),
+					// 				lastMaximum.gainunit.c_str(),
+					// 				it->channel.c_str(),
+					// 				it->gainunit.c_str() );
 					continue;
 			}
 

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -749,16 +749,18 @@ class App : public Client::StreamApplication {
 					)
 				);
 
-				if ( ( strcmp( it->second->gainUnit.c_str(), "M/S" ) == 0 ) 
-					|| ( strcmp( it->second->gainUnit.c_str(), "m/s" ) == 0 )) {
-						SEISCOMP_DEBUG("the new PGA from %s is based on an velocimeter [%s]",
+				if ( ( strcmp( it->second->gainUnit.c_str(), "M/S**2" ) != 0 ) 
+					&& ( strcmp( it->second->gainUnit.c_str(), "m/s**2" ) != 0 ) 
+					&& ( strcmp( it->second->gainUnit.c_str(), "M/S/S" ) != 0 ) 
+					&& ( strcmp( it->second->gainUnit.c_str(), "m/s/s" ) != 0 )) {
+						SEISCOMP_DEBUG("the new PGA from %s  [%s] IS NOT based on an accelerometer",
 										mseedid.c_str(),
 										it->second->gainUnit.c_str());
 						continue;
 				}
 				// else: the new PGA is based on an accelerograph
 				
-				SEISCOMP_DEBUG("the new PGA from %s is based on an accelerometer [%s]",
+				SEISCOMP_DEBUG("the new PGA from %s [%s] is based on an accelerometer",
 								mseedid.c_str(),
 								it->second->gainUnit.c_str());
 


### PR DESCRIPTION
Prevents the use of clipped data in further processing and adds additional logging and select the appropriate envelope for PGA processing based on instrument gain units.

> Before, scfinder would process with FinDer the maximum PGA over all the channels (vertical or horizontal) of all the colocated instruments.

Ambiguituous processing of vertical and horizontal PGA remains.

# Key Changes:

1. **Instrument Gain Unit Check and Prevailing (M/S\*\*2 by default)**:
   - Integrated logic to check and log whether PGA data is from an accelerometer based on the instrument's gain unit (i.e., "M/S**2").
   - Adjusted the PGA processing to ensure data from different instruments (e.g., accelerometers vs. velocimeters) at the same location is handled correctly, i.e., M/S**2 prevails on others by default.

> **Updates in the `updateMaximum`  Function (updates the PGA)**:
>    - Prevailing of preferred gain units over the others .
>    - Considering of clipped records while updating the maximum PGA.
   
2. **Discarding of Clipped data**:
   - Clipping is now detected, logged, and skipped in the PGA buffer processing.
   - Added logic to skip channels recently clipped within the `clipTimeout` window.
   - Modified log statements to include clipping status where necessary.

> **New `clipTimeout` Parameter**:
>    - Added a new configuration parameter, `clipTimeout`, in `scfinder.xml` to specify the delay after which clipped envelope are excluded from processing.
>    - Default value set to 30 seconds.
>    - Similar to [scvsmag's clipTimeout ](https://docs.gempa.de/sed-eew/current/apps/scvsmag.html#confval-vsmag.clipTimeout)
>    
> **Updates in the `Amplitude` Structure  (used for envelopes and PGAs)**:
>    -  Tracking of whether the data is clipped via a `clipped` boolean flag, and when that last occured via the  `lastclipped` timestamp.
>    - Added `gainUnit` string to keep track of the channel gainUnit.

3. **Improved Debug Logging**:
   - Logging clipped records and skipping logic.
   - Logging when amplitude is discarted to prefer another data gain units.
   - Logging gain unit information when available.

# Unit Test
The two new features can be tested with the unit test data as follows: 
```bash
scfinder --playback --offline --inventory-db file:///usr/local/src/seiscomp/src/base/sed-addons/test/vs/inventory.xml  --test -I file:///usr/local/src/seiscomp/src/base/sed-addons/test/vs/sorted.mseed --debug
```

1. **Instrument Gain Unit Check and Prevailing (M/S\*\*2 by default)**:
   - Prevailing logic logging for each collocated instrument when PGA is updated, e.g.: `HG [M/S**2] rules over HH [M/S]`
   - Setting "" (empty) instead of M/**2 as finder.preferredGainUnits in scfinder.cfg switches the revailing of any unit off as can be seen in `temp_data/*/data_*` files.
   - Setting M/S instead of M/**2 as finder.preferredGainUnits in scfinder.cfg switches collocated instrument usage from accelerometers to velocimeters as can be seen in `temp_data/*/data_*` files (e.g., 20 HG less in data_2).

2. **Discarding of clipped data**:
   - Log message for each clipped PGA that has been skipped: `Instrument clipped and skipped`
   - Log message after clipped PGA for 30s: `Instrument clipped recently and skipped`
   - Setting 2 as saturationThreshold  in scfinder.cfg allows 4 station contributions less as can be seen in `temp_data/*/data_*` files.