### PR TITLE
Use explicit time span to double casts or functions

### DIFF
--- a/apps/eew/sceewenv/main.cpp
+++ b/apps/eew/sceewenv/main.cpp
@@ -148,16 +148,16 @@ class App : public Client::StreamApplication {
 			                                  placeholders::_3,
 			                                  placeholders::_4));
 			_eewProc.setInventory(Client::Inventory::Instance()->inventory());
- 
+
 			if ( !_eewProc.init(configuration(), "eewenv.") )
 				return false;
- 
+
 			_eewProc.showConfig();
 			_eewProc.showRules();
 
 			if ( commandline().hasOption("dump-config") )
 				return true;
- 
+
 			if ( _startTime.valid() ) recordStream()->setStartTime(_startTime);
 			if ( _endTime.valid() ) recordStream()->setEndTime(_endTime);
 
@@ -292,7 +292,7 @@ class App : public Client::StreamApplication {
 					tmp.setChannelCode(proc->waveformID().channelCode());
 
 				tmp.setStartTime(timestamp);
-				tmp.setSamplingFrequency(1.0 / _eewProc.configuration().vsfndr.envelopeInterval);
+				tmp.setSamplingFrequency(1.0 / _eewProc.configuration().vsfndr.envelopeInterval.length());
 
 				FloatArrayPtr data = new FloatArray(1);
 				data->set(0, value);

--- a/apps/eew/scvsmag/scvsmag.cpp
+++ b/apps/eew/scvsmag/scvsmag.cpp
@@ -316,7 +316,7 @@ bool VsMagnitude::init() {
 	}
 
 	// set the timespan of the cache
-	_cache.setTimeSpan(TimeSpan(_timeout));
+	_cache.setTimeSpan(TimeSpan(_timeout, 0));
 
 	// get objects from the database if they are not in the cache
 	if ( isDatabaseEnabled() )
@@ -582,7 +582,7 @@ void VsMagnitude::handleEvent(Event *event) {
 		// set time to track how long it takes to estimate the magnitude
 		// and how long it took for the origin to arrive
 		vsevent->originArrivalTime = Core::Time::GMT();
-		
+
 		try {
 			vsevent->originCreationTime = org->creationInfo().creationTime();
 		}
@@ -742,7 +742,7 @@ void VsMagnitude::processEvents() {
 				for ( cev = _publishedEvents.begin();
 						cev != _publishedEvents.end(); ) {
 					if ( cev->second
-							< (_currentTime - Core::TimeSpan(_timeout)) ) {
+							< (_currentTime - Core::TimeSpan(_timeout, 0)) ) {
 						_publishedEvents.erase(cev++);
 						continue;
 					}
@@ -939,7 +939,7 @@ void VsMagnitude::process(VsEvent *evt, Event *event) {
 
 		for ( size_t i = 0; i < inputs.size(); ++i ) {
 			const VsInput &input = inputs[i];
-			
+
 			if ( Math::isNaN(input.mest)  ) {
                                 continue ;
                         }

--- a/libs/seiscomp/processing/eewamps/processors/envelope.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/envelope.cpp
@@ -92,7 +92,7 @@ void EnvelopeProcessor::process(const Record *rec, const DoubleArray &data) {
 	if ( !_stream.initialized ) {
 		SEISCOMP_INFO("%s: initializing envelope processor", rec->streamID().c_str());
 
-		_samplePool.reset((int)(rec->samplingFrequency()*_config->vsfndr.envelopeInterval+0.5)+1);
+		_samplePool.reset((int)(rec->samplingFrequency() * _config->vsfndr.envelopeInterval.length() + 0.5) + 1);
 		_dt = Core::TimeSpan(1.0 / rec->samplingFrequency());
 
 		setupTimeWindow(rec->startTime());
@@ -110,8 +110,8 @@ void EnvelopeProcessor::process(const Record *rec, const DoubleArray &data) {
 
 	if ( clipMask != NULL && ((unsigned int)data.size()) != clipMask->size() ) {
 		SEISCOMP_WARNING("%s: data.size() != clipMask->size() (%d != %zu)",
-		                  rec->streamID().c_str(), 
-						  data.size(), 
+		                  rec->streamID().c_str(),
+						  data.size(),
 						  clipMask->size());
 	}
 
@@ -147,7 +147,7 @@ void EnvelopeProcessor::process(const Record *rec, const DoubleArray &data) {
 
 			if ( ((unsigned int)i) >= clipMask->size() ){
 				SEISCOMP_WARNING("%s: cannot check if data[%d] is clipped (clip mask too short) unreliable data.",
-								rec->streamID().c_str(), 
+								rec->streamID().c_str(),
 								i);
 			}
 			ts += _dt;
@@ -163,7 +163,7 @@ void EnvelopeProcessor::process(const Record *rec, const DoubleArray &data) {
 void EnvelopeProcessor::setupTimeWindow(const Core::Time &ref) {
 	if ( _config->vsfndr.envelopeInterval.seconds() > 0 ) {
 		double r = floor(((double)ref / (double)_config->vsfndr.envelopeInterval));
-		_currentStartTime = r * _config->vsfndr.envelopeInterval;
+		_currentStartTime = r * _config->vsfndr.envelopeInterval.length();
 
 		// Fix for possible rounding errors
 		if ( ref.microseconds() == 0 )

--- a/libs/seiscomp/processing/eewamps/processors/gba.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/gba.cpp
@@ -217,11 +217,11 @@ void GbAProcessor::updateAndPublishTriggerAmplitudes(Trigger &trigger) {
 	for ( it = _amplitudeBuffer->begin(); it != _amplitudeBuffer->end(); ++it ) {
 		const GbARecord *rec = static_cast<const GbARecord*>(it->get());
 		if ( rec->endTime() <= trigger.time ) continue;
-		int startSample = (trigger.time-rec->startTime())*rec->samplingFrequency();
+		int startSample = (trigger.time - rec->startTime()).length() * rec->samplingFrequency();
 		if ( startSample < 0 ) startSample = 0;
 		if ( startSample >= rec->sampleCount() ) continue;
 
-		int endSample = (trigger.time+_config->gba.cutOffTime-rec->startTime())*rec->samplingFrequency()+1;
+		int endSample = (trigger.time + _config->gba.cutOffTime - rec->startTime()).length() * rec->samplingFrequency() + 1;
 		if ( endSample > rec->sampleCount() ) endSample = rec->sampleCount();
 
 		maxEvaluationTime = rec->startTime() + Core::TimeSpan(endSample/rec->samplingFrequency());

--- a/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
@@ -216,11 +216,11 @@ void OnsiteMagnitudeProcessor::updateAndPublishTriggerAmplitudes(Trigger &trigge
 	for ( it = _tauPBuffer.begin(); it != _tauPBuffer.end(); ++it ) {
 		const Record *rec = it->get();
 		if ( rec->endTime() <= startTime ) continue;
-		int startSample = (startTime-rec->startTime())*rec->samplingFrequency();
+		int startSample = (startTime - rec->startTime()).length() * rec->samplingFrequency();
 		if ( startSample < 0 ) startSample = 0;
 		if ( startSample >= rec->sampleCount() ) continue;
 
-		int endSample = (endTime-rec->startTime())*rec->samplingFrequency()+1;
+		int endSample = (endTime - rec->startTime()).length() * rec->samplingFrequency() + 1;
 		if ( endSample > rec->sampleCount() ) endSample = rec->sampleCount();
 
 		maxEvaluationTime = rec->startTime() + Core::TimeSpan(endSample/rec->samplingFrequency());
@@ -290,15 +290,16 @@ void OnsiteMagnitudeProcessor::updateAndPublishTriggerAmplitudes(Trigger &trigge
 				break;
 			}
 
-			startSample = (lastEndTime-rec->startTime())*rec->samplingFrequency();
+			startSample = (lastEndTime - rec->startTime()).length() * rec->samplingFrequency();
 		}
-		else
-			startSample = (trigger.time-rec->startTime())*rec->samplingFrequency();
+		else {
+			startSample = (trigger.time - rec->startTime()).length() * rec->samplingFrequency();
+		}
 
 		if ( startSample < 0 ) startSample = 0;
 		if ( startSample >= rec->sampleCount() ) continue;
 
-		int endSample = (endTime-rec->startTime())*rec->samplingFrequency()+1;
+		int endSample = (endTime - rec->startTime()).length() * rec->samplingFrequency() + 1;
 		if ( endSample > rec->sampleCount() ) endSample = rec->sampleCount();
 		else {
 			double r = integralVelocity / integralDisplacement;

--- a/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
+++ b/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
@@ -193,12 +193,12 @@ Record *GainAndBaselineCorrectionRecordFilter<T>::feed(const Record *rec) {
 	if ( clipMask ) {
 		//std::cerr << rec->streamID() << ": set clip mask: clipped = " << clipMask->numberOfBitsSet() << std::endl;
 		SEISCOMP_INFO("%s: set clip mask: clipped = %zu",
-		              rec->streamID().c_str(), 
+		              rec->streamID().c_str(),
 					  clipMask->numberOfBitsSet());
 		SEISCOMP_DEBUG("%s: rec.size()=%d clipMask->size()=%zu correctedData->size()=%d",
-		               rec->streamID().c_str(), 
-					   rec->data()->size(), 
-					   clipMask->size(), 
+		               rec->streamID().c_str(),
+					   rec->data()->size(),
+					   clipMask->size(),
 					   correctedData->size());
 	}
 
@@ -220,7 +220,7 @@ Record *GainAndBaselineCorrectionRecordFilter<T>::feed(const Record *rec) {
 			Core::TimeSpan diff = rec->startTime() - _lastEndTime;
 			// Overlap or gap does not matter, we need to reset the filter
 			// for non-continuous records
-			if ( fabs(diff) > (0.5/_samplingFrequency) ) {
+			if ( fabs(diff.length()) > (0.5 / _samplingFrequency) ) {
 				SEISCOMP_DEBUG("[%s] discontinuity of %fs: reset filter",
 				               rec->streamID().c_str(), (double)diff);
 				_baselineCorrection.reset();


### PR DESCRIPTION
This change compiles with SeisComP API 17 which removes implicit double casts from Time and TimeSpan.