### PR TITLE
[recordstream/vs] Fix compilation with API 17

### DIFF
--- a/plugins/recordstream/vs/recordstream.cpp
+++ b/plugins/recordstream/vs/recordstream.cpp
@@ -202,8 +202,7 @@ bool VSConnection::addStream(const string &net, const string &sta,
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 bool VSConnection::addStream(const string &net, const string &sta,
                              const string &loc, const string &cha,
-                             const Seiscomp::Core::Time &,
-                             const Seiscomp::Core::Time &) {
+                             const TimeType &, const TimeType &) {
 	return addStream(net, sta, loc, cha);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -212,7 +211,7 @@ bool VSConnection::addStream(const string &net, const string &sta,
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool VSConnection::setStartTime(const Seiscomp::Core::Time &) {
+bool VSConnection::setStartTime(const TimeType &) {
 	return true;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -221,7 +220,7 @@ bool VSConnection::setStartTime(const Seiscomp::Core::Time &) {
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool VSConnection::setEndTime(const Seiscomp::Core::Time &) {
+bool VSConnection::setEndTime(const TimeType &) {
 	return true;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/plugins/recordstream/vs/recordstream.h
+++ b/plugins/recordstream/vs/recordstream.h
@@ -22,6 +22,7 @@
 #include <seiscomp/core/interruptible.h>
 #include <seiscomp/core/datetime.h>
 #include <seiscomp/core/genericrecord.h>
+#include <seiscomp/core/version.h>
 #include <seiscomp/io/recordstream.h>
 #include <seiscomp/io/recordstream/streamidx.h>
 #include <seiscomp/datamodel/vs/vs_package.h>
@@ -70,40 +71,49 @@ struct Node {
 
 class VSConnection : public Seiscomp::IO::RecordStream {
 	public:
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
+		using TimeType = Seiscomp::Core::Time;
+#else
+		using TimeType = OPT(Seiscomp::Core::Time);
+#endif
+
+
+	public:
 		//! C'tor
 		VSConnection();
-		
+
 		//! Destructor
-		virtual ~VSConnection();
+		~VSConnection() override;
 
 	public:
 		//! Initialize the arclink connection.
-		virtual bool setSource(const std::string &source);
-		
-		virtual bool addStream(const std::string &networkCode,
-		                       const std::string &stationCode,
-		                       const std::string &locationCode,
-		                       const std::string &channelCode);
+		bool setSource(const std::string &source) override;
 
-		virtual bool addStream(const std::string &networkCode,
-		                       const std::string &stationCode,
-		                       const std::string &locationCode,
-		                       const std::string &channelCode,
-		                       const Seiscomp::Core::Time &startTime,
-		                       const Seiscomp::Core::Time &endTime);
-  
+		bool addStream(const std::string &networkCode,
+		               const std::string &stationCode,
+		               const std::string &locationCode,
+		               const std::string &channelCode) override;
+
+		bool addStream(const std::string &networkCode,
+		               const std::string &stationCode,
+		               const std::string &locationCode,
+		               const std::string &channelCode,
+		               const TimeType &startTime,
+		               const TimeType &endTime) override;
+
 		//! Adds the given start time to the server connection description
-		virtual bool setStartTime(const Seiscomp::Core::Time &stime);
-		
+		bool setStartTime(const TimeType &stime) override;
+
 		//! Adds the given end time to the server connection description
-		virtual bool setEndTime(const Seiscomp::Core::Time &etime);
+		bool setEndTime(const TimeType &etime) override;
 
 		//! Terminates the arclink connection.
-		virtual void close();
+		void close() override;
 
 		//! Returns the data stream
-		virtual Seiscomp::Record *next();
+		Seiscomp::Record *next() override;
 
+	private:
 		//! Removes all stream list, time window, etc. -entries from the connection description object.
 		bool clear();
 


### PR DESCRIPTION
Due to changes to the IO::RecordStream interface, this plugins needs to be ported to take both API flavours into account.