### PR TITLE
[processing] Port to SC API 17

### DIFF
--- a/libs/seiscomp/processing/eewamps/preprocessor.cpp
+++ b/libs/seiscomp/processing/eewamps/preprocessor.cpp
@@ -565,7 +565,11 @@ HPreProcessor::HPreProcessor(const Config *config) : PreProcessor(config) {
 	// since both horizontals are combined into a single component
 	setUsedComponent(FirstHorizontal);
 
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 	Core::SmartPointer<L2NormOperator>::Impl op = new L2NormOperator(OpWrapper(this, FirstHorizontalComponent, SecondHorizontalComponent));
+#else
+	Core::SmartPointer<L2NormOperator> op = new L2NormOperator(OpWrapper(this, FirstHorizontalComponent, SecondHorizontalComponent));
+#endif
 	op->setRingBufferSize(_config->horizontalBufferSize);
 	_l2norm = op;
 	setOperator(_l2norm.get());
@@ -614,7 +618,11 @@ bool HPreProcessor::compile(const DataModel::WaveformStreamID &id) {
 
 	typedef HPreProcessor::L2Norm<double> OpWrapper;
 	typedef StreamOperator<2,OpWrapper> L2NormOperator;
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 	Core::SmartPointer<L2NormOperator>::Impl op;
+#else
+	Core::SmartPointer<L2NormOperator> op;
+#endif
 
 	if ( _coLocatedFilter ) {
 		if ( _unit == MeterPerSecond ) {

--- a/libs/seiscomp/processing/eewamps/processors/gba.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/gba.cpp
@@ -19,6 +19,7 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
+#include <seiscomp/core/version.h>
 #include <seiscomp/logging/log.h>
 #include <seiscomp/math/filter/butterworth.h>
 #include <seiscomp/datamodel/pick.h>
@@ -166,7 +167,11 @@ void GbAProcessor::process(const Record *rec, const DoubleArray &data) {
 		SEISCOMP_DEBUG("  filter bank range %f-%fHz", loFreq, hiFreq);
 	}
 
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 	Core::SmartPointer<GbARecord>::Impl gbaRec = new GbARecord(_config->gba.passbands.size(), *rec);
+#else
+	Core::SmartPointer<GbARecord> gbaRec = new GbARecord(_config->gba.passbands.size(), *rec);
+#endif
 	gbaRec->setData(new DoubleArray(data));
 
 	for ( size_t i = 0; i < _config->gba.passbands.size(); ++i ) {

--- a/libs/seiscomp/processing/eewamps/processors/gba.h
+++ b/libs/seiscomp/processing/eewamps/processors/gba.h
@@ -16,11 +16,12 @@
  ******************************************************************************/
 
 
-#ifndef __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_GBA_H__
-#define __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_GBA_H__
+#ifndef SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_GBA_H
+#define SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_GBA_H
 
 
 #include <seiscomp/core/recordsequence.h>
+#include <seiscomp/core/version.h>
 #include "../baseprocessor.h"
 
 
@@ -108,7 +109,11 @@ class SC_LIBEEWAMPS_API GbAProcessor : public BaseProcessor {
 	//  Private members
 	// ----------------------------------------------------------------------
 	private:
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 		typedef Core::SmartPointer<Filter>::Impl FilterPtr;
+#else
+		typedef Core::SmartPointer<Filter> FilterPtr;
+#endif
 		typedef std::deque<TriggerPtr> TriggerBuffer;
 
 		FilterPtr     *_filterBank;

--- a/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
+++ b/libs/seiscomp/processing/eewamps/processors/onsitemag.cpp
@@ -19,6 +19,7 @@
 #define SEISCOMP_COMPONENT EEWAMPS
 
 
+#include <seiscomp/core/version.h>
 #include <seiscomp/logging/log.h>
 #include <seiscomp/datamodel/pick.h>
 #include <seiscomp/io/records/mseedrecord.h>
@@ -159,7 +160,11 @@ void OnsiteMagnitudeProcessor::process(const Record *rec, const DoubleArray &dat
 	// Save tauC record
 	copyData = new DoubleArray(data);
 
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 	Core::SmartPointer<TauCRecord>::Impl tauCRecord = new TauCRecord(*rec);
+#else
+	Core::SmartPointer<TauCRecord> tauCRecord = new TauCRecord(*rec);
+#endif
 	tauCRecord->setData(copyData.get());
 	tauCRecord->displacement.setData(data.size(), data.typedData());
 	_displacementFilter.apply(tauCRecord->displacement.size(), tauCRecord->displacement.typedData());

--- a/libs/seiscomp/processing/eewamps/processors/onsitemag.h
+++ b/libs/seiscomp/processing/eewamps/processors/onsitemag.h
@@ -16,11 +16,12 @@
  ******************************************************************************/
 
 
-#ifndef __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_ONSITEMAG_H__
-#define __SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_ONSITEMAG_H__
+#ifndef SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_ONSITEMAG_H
+#define SEISCOMP_PROCESSING_EEWAMPS_PROCESSORS_ONSITEMAG_H
 
 
 #include <seiscomp/core/recordsequence.h>
+#include <seiscomp/core/version.h>
 #include <seiscomp/math/filter/butterworth.h>
 #include <seiscomp/math/filter/iirintegrate.h>
 #include "../baseprocessor.h"
@@ -90,7 +91,11 @@ class SC_LIBEEWAMPS_API OnsiteMagnitudeProcessor : public BaseProcessor {
 	//  Private members
 	// ----------------------------------------------------------------------
 	private:
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 		typedef Core::SmartPointer<Filter>::Impl FilterPtr;
+#else
+		typedef Core::SmartPointer<Filter> FilterPtr;
+#endif
 		typedef std::deque<Trigger> TriggerBuffer;
 
 		TriggerBuffer                                    _triggerBuffer;

--- a/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
+++ b/libs/seiscomp/processing/eewamps/recordfilter/gainandbaselinecorrection.cpp
@@ -23,6 +23,7 @@
 #include <seiscomp/core/typedarray.h>
 #include <seiscomp/core/genericrecord.h>
 #include <seiscomp/core/exceptions.h>
+#include <seiscomp/core/version.h>
 #include <seiscomp/datamodel/utils.h>
 
 #include "gainandbaselinecorrection.h"
@@ -164,7 +165,11 @@ Record *GainAndBaselineCorrectionRecordFilter<T>::feed(const Record *rec) {
 	if ( sourceData == NULL )
 		return NULL;
 
+#if SC_API_VERSION < SC_API_VERSION_CHECK(17,0,0)
 	typename Core::SmartPointer< NumericArray<T> >::Impl correctedData;
+#else
+	Core::SmartPointer< NumericArray<T> > correctedData;
+#endif
 
 	correctedData = (NumericArray<T>*)sourceData->copy(dispatchType<T>());
 	if ( !correctedData ) {


### PR DESCRIPTION
This PR ports to the upcoming SeisComP library API 17. In particular it replaces `SmartPointer<T>::Impl` with `SmartPointer<T>`.