### PR TITLE
[finder] docs: address common errors in finder setup

### DIFF
--- a/doc/base/setup-finder.rst
+++ b/doc/base/setup-finder.rst
@@ -7,10 +7,15 @@ FinDer setup
 Containerization  
 ----------------
 
-This requires `docker <https://docs.docker.com/engine/install/>`_ and ``ssh`` to be installed and enabled.  
+This requires `docker <https://docs.docker.com/engine/install/>`_ and ``ssh`` to be installed and enabled. You need to ask access to the finder package for your github account and accept the invitation.  
 
-#. First make sure that you complete ``docker login ghcr.io/sed-eew/finder`` (`authenticating to the container registry <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry>`_)
-#. Start the docker (only once or when updating docker image, old docker version: replace ``host-gateway`` by ``$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')``):: 
+#. First make sure that you complete ``docker login ghcr.io/sed-eew/finder`` (`authenticating to the container registry <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry>`_). You need to generate a new Token (classic) from your github account with the ``read:packages`` option enabled.
+
+#. Download the finder docker image (only once):: 
+
+    docker pull ghcr.io/sed-eew/finder:master 
+
+#. Start the docker (only once or when updating docker image. For old docker versions: replace ``host-gateway`` by ``$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')``):: 
 
     docker stop finder && docker rm finder # That is in case you update an existing one 
     docker run -d \
@@ -107,4 +112,13 @@ Operation
     utilities in ``/usr/local/src/FinDer/``.
 
 
+Common warnings and errors
+---------
 
+* **scmaster is not running [warning]** (in the running finder container): this is normal, scmaster is running on the host, not in the finder container. You can ignore this warning.
+
+* **NET.STA.LOC.CODE: max delay exceeded: XXXXs** (in scfinder log): this is a warning about your data streaming delays. See our section about optimizing data delays for EEW (coming soon). You can also adjust the maximum delay before issuing a warning in the :file:`scfinder.cfg` configuration file with the parameter ``debug.maxDelay``.
+
+* **Connection error: Client name not unique** (in scfinder log): this means that you have two (or more) scfinder instances running with the same name. You need to find and kill the duplicate instances in the docker container and/or host.
+
+* **Unit error** (in scfinder log): check your station metadata and/or remove the problematic channel(s) using the ``streams.blacklist`` parameter in the :file:`scfinder.cfg` configuration file.   

--- a/doc/base/setup-finder.rst
+++ b/doc/base/setup-finder.rst
@@ -112,6 +112,15 @@ Operation
     utilities in ``/usr/local/src/FinDer/``.
 
 
+Offline testing
+---------
+To test finder offline on a given earthquake, copy the corresponding mseed data in the container, starting at least 1 min before the origin time (OT) and ending at least 2 min after the OT.
+Then run:
+    scfinder --offline --playback -I data.mseed
+
+The xml output should include FinDer solutions every seconds with rupture line parameters and their PDF.
+
+
 Common warnings and errors
 ---------
 

--- a/doc/base/setup-finder.rst
+++ b/doc/base/setup-finder.rst
@@ -114,10 +114,10 @@ Operation
 
 Offline testing
 ---------------
-To test finder offline on a given earthquake, copy the corresponding mseed data in the container, starting at least 1 min before the origin time (OT) and ending at least 2 min after the OT.
+To test finder offline on a given earthquake, copy the corresponding mseed data and inventory in the container, starting at least 1 min before the origin time (OT) and ending at least 2 min after the OT.
 Then run::
     
-    seiscomp-finder exec scfinder --offline --playback -I data.mseed
+    seiscomp-finder exec scfinder --offline --playback --inventory-db inventory.xml -I data.mseed
 
 The xml output should include FinDer solutions every seconds with rupture line parameters and their PDF.
 
@@ -125,10 +125,8 @@ The xml output should include FinDer solutions every seconds with rupture line p
 Common warnings and errors
 --------------------------
 
-* **scmaster is not running [warning]** (in the running finder container): this is normal, scmaster is running on the host, not in the finder container. You can ignore this warning.
+* **scmaster is not running [warning]** (in the running finder container): ignore if scfinder is setup to connect to a messaging system outside of the finder container.
 
-* **NET.STA.LOC.CODE: max delay exceeded: XXXXs** (in scfinder log): this is a warning about your data streaming delays. See our section about optimizing data delays for EEW (coming soon). You can also adjust the maximum delay before issuing a warning in the :file:`scfinder.cfg` configuration file with the parameter ``debug.maxDelay``.
+* **NET.STA.LOC.CODE: max delay exceeded: XXXXs** (in scfinder log): see the parameter `debug.maxDelay <https://docs.gempa.de/sed-eew/current/apps/scfinder.html#confval-debug.maxDelay>`_.
 
-* **Connection error: Client name not unique** (in scfinder log): this means that you have two (or more) scfinder instances running with the same name. You need to find and kill the duplicate instances in the docker container and/or host.
-
-* **Unit error** (in scfinder log): check your station metadata and/or remove the problematic channel(s) using the ``streams.blacklist`` parameter in the :file:`scfinder.cfg` configuration file.   
+* **Unit error** (in scfinder log): check your station metadata and/or remove the problematic channel(s) using the `streams.blacklist <https://docs.gempa.de/sed-eew/current/apps/scfinder.html#confval-streams.blacklist>`_ parameter in the :file:`scfinder.cfg` configuration file.   

--- a/doc/base/setup-finder.rst
+++ b/doc/base/setup-finder.rst
@@ -113,16 +113,17 @@ Operation
 
 
 Offline testing
----------
+---------------
 To test finder offline on a given earthquake, copy the corresponding mseed data in the container, starting at least 1 min before the origin time (OT) and ending at least 2 min after the OT.
-Then run:
-    scfinder --offline --playback -I data.mseed
+Then run::
+    
+    seiscomp-finder exec scfinder --offline --playback -I data.mseed
 
 The xml output should include FinDer solutions every seconds with rupture line parameters and their PDF.
 
 
 Common warnings and errors
----------
+--------------------------
 
 * **scmaster is not running [warning]** (in the running finder container): this is normal, scmaster is running on the host, not in the finder container. You can ignore this warning.
 


### PR DESCRIPTION
Improve the finder setup documentation by adding a section on common errors and warnings, and a section on how to perform offline tests with scfinder. Also add more details about docker registry access with token.

@FMassin, these should cover the recent errors/warnings reported   
