### PR TITLE
[scfinder] Add origin filter

### DIFF
--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -125,6 +125,20 @@
 						(empty) to disable prevailing.
 					</description>
 				</parameter>
+				<parameter name="regionFile" type="string" default="">
+					<description>
+					Set the full file path to the BNA file that contains the region(s) used for filtering 
+					finder solutions. Geographic filtering requires both "regionFile" and "regionNames" 
+					to be defined and valid.
+					</description>
+				</parameter>
+				<parameter name="regionNames" type="string" default="">
+					<description>
+					Defines the name(s) of the region(s), as a comma-separated list, within which finder 
+					solutions should be filtered. Geographic filtering requires both "regionFile" and 
+					"regionNames" to be defined and valid.
+					</description>
+				</parameter>
 			</group>
 			<group name="debug">
 				<parameter name="maxDelay" type="double" default="3" unit="s">


### PR DESCRIPTION
Adds the possibility to filter finder solution based on epicenter location.

# New parameters: 
  - `regionFile`: full file path to [BNA file](https://www.seiscomp.de/doc/apps/global_gui.html#boundary-file-format-bna). 
  - `regionNames`: comma-separated string of polygon names in `regionFile`

# Implementation:
- If both new parameters are defined and valid, only the finder solution with epicenter location with configure  polygon(s) with be sent.
- The implementation of the filter is at the beginning of method `sendfinder`, skips sending if no configured polygons matches with the solution epicenter.

# Backward compatibility
By default both parameters are empty and filter is disabled (any finder solution can be sent).

# Testing
Using in `scfdalpine.cfg` :
```
finder.regionNames = filterregion
finder.regionFile = /home/sysop/.seiscomp/filterfile.bna
```
and in `~/.seiscomp/filterfile.bna` :
```
"filterregion","rank 1",5
8,45
10,45
10,47
8,47
8,45
```
with command:
```
 /opt/seiscomp/bin/seiscomp exec scfdalpine \
            --offline \
            --playback \
            --debug \
            --inventory-db file:///usr/local/src/seiscomp/src/base/sed-addons/test/vs/inventory.xml \
            --record-file /usr/local/src/seiscomp/src/base/sed-addons/test/vs/sorted.mseed
```

Will return solution in xml output. Any inconsistency between `regionFile ` and `regionName` in the scfinder configuration file or the BNA file  will not allow `scfdalpine` to start.  

In case of an inconsistent `regionFile` , the following is logged before termination:
```
[error] "Failed to open region file /home/sysop/.seiscomp/filt.bna
```

In case of an inconsistent `regionName` , the following is logged before termination:
```
[error] No polygon in /home/sysop/.seiscomp/filt.bna matches any name in regionNames: ,filter,
```

In case of a finder solution is an valid region, the following is logged before sending the solution:
```
[debug] FinDer epicenter (lat: 46.907519  lon: 9.098432) is within region filter
```

In case of a finder solution is not in any valid region, the following is logged:
```
[debug] FinDer epicenter (lat: 46.907519  lon: 9.098432) is not within any provided region ,filter,
```

# Review  
🙏 @maboese and @Thom-P : Please double-check that it make sense and it is functional.

Thank you!  