### PR TITLE
[Finder] docs: add a playback tutorial and add extra Finder setup infos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Documentation
 
+  * [#75](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/pull/75): Create docker playback tutorial section and add extra finder setup infos.
+  
   * [#72](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/pull/72): Fixes FinDer setup.
 
 * sceewlog

--- a/doc/base/setup-finder.rst
+++ b/doc/base/setup-finder.rst
@@ -117,7 +117,8 @@ Operation
 #. Manage :ref:`scfinder` (and SeisComP) with the ``seiscomp-finder`` shortcut, e.g.::
 
     # debug and test:
-    seiscomp-finder exec scfinder --debug
+    docker exec -u sysop -it finder \
+        /opt/seiscomp/bin/seiscomp exec scfinder --debug
 
     # enable modules
     seiscomp-finder enable scfinder 

--- a/doc/base/tuto-playbacks.rst
+++ b/doc/base/tuto-playbacks.rst
@@ -90,7 +90,7 @@ Configuration
 
 #. (Optional) You can also activate sceewlog in the docker to get a report log of the alerts::
 
-    docker exec -u sysop -it scpbd pip3 install pip install python-dateutil  # library needed for sceewlog
+    docker exec -u sysop -it scpbd pip3 install python-dateutil  # library needed for sceewlog
     docker exec -u sysop -it scpbd /opt/seiscomp/bin/seiscomp enable sceewlog
 
 #. Import your own configuration in the user directory. These can be your `.cfg` files, bindings, `finder.config`, and finder mask::

--- a/doc/base/tuto-playbacks.rst
+++ b/doc/base/tuto-playbacks.rst
@@ -1,0 +1,108 @@
+.. _PLAYBACKS:
+
+============
+Playbacks
+============
+
+Principle
+---------
+
+We provide tools to reprocess data within a real-time simulation environment according to the original data timestamps. This allows to evaluate realistic EEW delays for any event recorded with a representative network. This also facilitates testing of configuration parameters for improvement. This work is based on https://github.com/yannikbehr/sc3-playback developed by @yannikbehr.
+
+The playback in a docker comes with:
+- a pre-configured scautoloc for rapid earthquake location
+- basic configuration for appropriate VS magnitude amd origin association
+- a basic FinDer configuration with generic symmetric crustal template (access upon request)
+
+Containerization  
+----------------
+
+SeisComP's `msrtsimul <https://www.seiscomp.de/doc/apps/msrtsimul.html>_` module simulates a real-time data acquisition by injecting miniSEED data from a file into the seedlink buffer. Its usage requires configuring a dedicated seedlink server appropriately for msrtsimul and the related metadata.
+
+Using our `scpd <https://github.com/FMassin/scpbd/pkgs/container/scpbd>` tool (SeisComP playback in a docker), the playbacks can be performed without altering your system's configuration. Note that scpd includes VS but not finder. If you are one of our external collaborators, you can also our finder docker container to perform playbacks that also include finder.
+
+This requires `docker <https://docs.docker.com/engine/install/>`_ and ``ssh`` to be installed and enabled.
+
+#. First make sure that you complete ``docker login ghcr.io/fmassin/scpbd`` (`authenticating to the container registry <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry>`_). You need to generate a new Token (classic) from your github account with the ``read:packages`` option enabled. If you have been granted access to the finder container, use instead ``docker login ghcr.io/sed-eew/finder``
+
+#. Download the scpbd/finder docker image (only once):: 
+
+    docker pull ghcr.io/fmassin/scpbd:main 
+    # or for finder:
+    docker pull ghcr.io/sed-eew/finder:v5.5.3.multipolygon 
+
+#. Start the docker (only once or when updating docker image. For old docker versions: replace ``host-gateway`` by ``$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')``):: 
+
+    docker stop scpdb && docker rm scpdb # That is in case you update an existing one 
+    docker run -d \
+        --add-host=host.docker.internal:host-gateway  \
+        -p 18022:18000 -p 222:22 \
+        --name scpbd \
+        ghcr.io/fmassin/scpbd:main 
+        # or for finder:
+        ghcr.io/sed-eew/finder:v5.5.3.multipolygon
+
+
+#. Allow the container to access data from the host:: 
+    
+    docker exec -u 0  -it scpbd ssh-keygen -t rsa -N '' 
+    docker exec -u 0  -it scpbd ssh-copy-id $USER@host.docker.internal
+
+
+#. Define a shortcut function:: 
+
+    scpbd () { docker exec -u 0  -it scpbd main $@ ; }
+
+
+Configuration 
+-------------
+
+#. Enable the required SeisComP automatic processing modules::     
+    
+    docker exec -u sysop  -it scpbd /opt/seiscomp/bin/seiscomp enable scautopick scamp scautoloc scevent sceewenv scvsmag scfinder
+
+#. Import your own configuration, using the user directory::  
+    
+    docker cp <path to your config file> scpbd:/home/sysop/.seiscomp/
+
+#. Revise the default configuration:
+    
+    ssh -X -p 222 sysop@localhost  /opt/seiscomp/bin/seiscomp exec scconfig
+    # Nb: sysop password is ``sysop``
+
+Usage
+-----
+
+#. Prepare the data::
+
+    #The mseed data should include at least 1 min of noise before the origin time (OT) and end at least 2 min after the OT. The record length must be 512 Bytes and can be prepared if needed with:
+    ms512 () { python -c "from obspy import read; read('$1').write('$2', format='MSEED', reclen=512) ; exit()" ; }
+    ms512 data_not512.mseed data.mseed
+
+    #The station metadata should be formatted in the fdsnxml or scml format, and units should be M, M/S, or M/S/S.
+
+#. Start the playback::
+
+    scpbd $USER@host.docker.internal:$(pwd)/data.mseed \
+    $USER@host.docker.internal:$(pwd)/inv.xml,scml
+    # for a scml inventory format, or:
+    scpbd $USER@host.docker.internal:$(pwd)/data.mseed \
+    $USER@host.docker.internal:$(pwd)/inv.xml,fdsnxml
+    # for a fdsnxml inventory format.
+
+#. (Optional) Check the data stream::
+    
+    slinktool -Q localhost:18022 
+    scrttv -I slink://localhost:18022 
+
+#. Get and inspect the results::
+    
+    docker cp scpbd:/home/sysop/event_db.sqlite ./  
+    scolv -I file://data.mseed \
+    -d sqlite3://event_db.sqlite  \
+    --offline --debug
+
+.. note::
+
+    This is a placeholder
+

--- a/doc/base/tuto-playbacks.rst
+++ b/doc/base/tuto-playbacks.rst
@@ -7,46 +7,67 @@ Playbacks
 Principle
 ---------
 
-We provide tools to reprocess data within a real-time simulation environment according to the original data timestamps. This allows to evaluate realistic EEW delays for any event recorded with a representative network. This also facilitates testing of configuration parameters for improvement. This work is based on https://github.com/yannikbehr/sc3-playback developed by @yannikbehr.
+We provide containerized tools to reprocess data within a real-time simulation environment according to the original data timestamps.
+This allows to evaluate realistic EEW delays for any event recorded with a representative network.
+This also facilitates the testing of configuration parameters for improvement. 
+This work was initiated by `Yannik Behr <https://github.com/yannikbehr/sc3-playback>`_ and extended by `Fred Massin <https://github.com/FMassin/scpbd/pkgs/container/scpbd>`_.
 
 The playback in a docker comes with:
-- a pre-configured scautoloc for rapid earthquake location
-- basic configuration for appropriate VS magnitude amd origin association
-- a basic FinDer configuration with generic symmetric crustal template (access upon request)
+
+* a pre-configured scautoloc for rapid earthquake location
+* a basic configuration for appropriate VS magnitude and origin association
+* a basic FinDer configuration with generic symmetric crustal template (access upon request)
 
 Containerization  
 ----------------
 
-SeisComP's `msrtsimul <https://www.seiscomp.de/doc/apps/msrtsimul.html>_` module simulates a real-time data acquisition by injecting miniSEED data from a file into the seedlink buffer. Its usage requires configuring a dedicated seedlink server appropriately for msrtsimul and the related metadata.
+SeisComP's `msrtsimul <https://www.seiscomp.de/doc/apps/msrtsimul.html>`_ module simulates 
+a real-time data acquisition by injecting miniSEED data from a file into the seedlink buffer.
+Its usage requires configuring a dedicated seedlink server appropriately for `msrtsimul` and the related metadata.
 
-Using our `scpd <https://github.com/FMassin/scpbd/pkgs/container/scpbd>` tool (SeisComP playback in a docker), the playbacks can be performed without altering your system's configuration. Note that scpd includes VS but not finder. If you are one of our external collaborators, you can also our finder docker container to perform playbacks that also include finder.
+Using our `scpbd <https://github.com/FMassin/scpbd/pkgs/container/scpbd>`_ tool (SeisComP playback in a docker), 
+the playbacks can be performed without altering your system's configuration. Note that `scpbd` includes VS but not finder. 
+If you are one of our external collaborators, you can also use our `finder <https://github.com/SED-EEW/FinDer/pkgs/container/finder>`_ 
+container (requires permission) to perform playbacks that also include `finder`. This requires `docker <https://docs.docker.com/engine/install/>`_ and `ssh` to be installed and enabled.
 
-This requires `docker <https://docs.docker.com/engine/install/>`_ and ``ssh`` to be installed and enabled.
+In the following, we will use the variables ``IMAGE`` and ``TAG`` to remain general. You can define those according to the container you will use.
 
-#. First make sure that you complete ``docker login ghcr.io/fmassin/scpbd`` (`authenticating to the container registry <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry>`_). You need to generate a new Token (classic) from your github account with the ``read:packages`` option enabled. If you have been granted access to the finder container, use instead ``docker login ghcr.io/sed-eew/finder``
+For the scpbd docker image (unrestricted access)::
+    
+    IMAGE="ghcr.io/fmassin/scpbd"
+    TAG="main"
 
-#. Download the scpbd/finder docker image (only once):: 
+And for the finder docker image (restricted access)::
 
-    docker pull ghcr.io/fmassin/scpbd:main 
-    # or for finder:
-    docker pull ghcr.io/sed-eew/finder:v5.5.3.multipolygon 
+    IMAGE="ghcr.io/sed-eew/finder"
+    TAG="v5.5.3.multipolygon"
 
-#. Start the docker (only once or when updating docker image. For old docker versions: replace ``host-gateway`` by ``$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')``):: 
+.. note::
+    The version of the finder docker image for playback (``TAG="v5.5.3.multipolygon"``) is currently different than the one 
+    for :ref:`real time monitoring<DOCKERFINDER>` (``TAG="master"``).
+    This will change shortly as we update all our playback containers to the latest SeisComP version.
 
-    docker stop scpdb && docker rm scpdb # That is in case you update an existing one 
+#. First make sure to `authenticate to the container registry <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry>`_. You need to generate a new Token (classic) from your github account with the ``read:packages`` option enabled:: 
+
+    docker login $IMAGE
+
+#. Download the docker image (only once):: 
+
+    docker pull $IMAGE:$TAG 
+
+#. Start the docker (only once or when updating the docker image). For old docker versions: replace ``host-gateway`` by ``$(ip addr show docker0 | grep -Po 'inet \K[\d.]+')``:: 
+
+    docker stop scpbd && docker rm scpbd # That is in case you update an existing one 
     docker run -d \
         --add-host=host.docker.internal:host-gateway  \
         -p 18022:18000 -p 222:22 \
         --name scpbd \
-        ghcr.io/fmassin/scpbd:main 
-        # or for finder:
-        ghcr.io/sed-eew/finder:v5.5.3.multipolygon
-
+        $IMAGE:$TAG 
 
 #. Allow the container to access data from the host:: 
     
-    docker exec -u 0  -it scpbd ssh-keygen -t rsa -N '' 
-    docker exec -u 0  -it scpbd ssh-copy-id $USER@host.docker.internal
+    docker exec -u 0 -it scpbd ssh-keygen -t rsa -N '' 
+    docker exec -u 0 -it scpbd ssh-copy-id $USER@host.docker.internal
 
 
 #. Define a shortcut function:: 
@@ -59,38 +80,52 @@ Configuration
 
 #. Enable the required SeisComP automatic processing modules::     
     
-    docker exec -u sysop  -it scpbd /opt/seiscomp/bin/seiscomp enable scautopick scamp scautoloc scevent sceewenv scvsmag scfinder
+    docker exec -u sysop  -it scpbd /opt/seiscomp/bin/seiscomp enable \
+    scautopick scamp scautoloc scevent sceewenv scvsmag scfinder
 
-#. Import your own configuration, using the user directory::  
+#. Import your own configuration (optional), using the user directory. These can be your `.cfg` files, bindings, `finder.config`, and finder mask::
     
     docker cp <path to your config file> scpbd:/home/sysop/.seiscomp/
 
-#. Revise the default configuration:
+#. Revise the default configuration::
     
-    ssh -X -p 222 sysop@localhost  /opt/seiscomp/bin/seiscomp exec scconfig
-    # Nb: sysop password is ``sysop``
+    ssh -X -p 222 sysop@localhost /opt/seiscomp/bin/seiscomp exec scconfig 
+    # nb: sysop password is "sysop"
+
+
+Example dataset
+---------------
+
+To test the playback setup, you can use our `example dataset <https://doi.org/10.5281/zenodo.11192289>`_ 
+from the MLh 4.3 earthquake on October 25, 2020 in Elm (Switzerland).
+
 
 Usage
 -----
 
-#. Prepare the data::
+.. note::
+    File permissions: make sure everyone has reading rights on the data and metadata files you will use. 
+    The station metadata should be formatted in the `fdsnxml` or `scml` format, and units should be `M`, `M/S`, or `M/S/S`.
 
-    #The mseed data should include at least 1 min of noise before the origin time (OT) and end at least 2 min after the OT. The record length must be 512 Bytes and can be prepared if needed with:
-    ms512 () { python -c "from obspy import read; read('$1').write('$2', format='MSEED', reclen=512) ; exit()" ; }
+#. Prepare the data. The mseed data should include at least 1 min of noise before the origin time (OT) and end at least 2 min after the OT. The record length must be 512 Bytes and can be prepared if needed with::
+
+    ms512 () { python -c "from obspy import read; \
+    read('$1').write('$2', format='MSEED', reclen=512); \
+    exit()"; }
     ms512 data_not512.mseed data.mseed
-
-    #The station metadata should be formatted in the fdsnxml or scml format, and units should be M, M/S, or M/S/S.
 
 #. Start the playback::
 
+    # For a scml inventory format, use:
     scpbd $USER@host.docker.internal:$(pwd)/data.mseed \
     $USER@host.docker.internal:$(pwd)/inv.xml,scml
-    # for a scml inventory format, or:
+    
+    # And for a fdsnxml inventory format:
     scpbd $USER@host.docker.internal:$(pwd)/data.mseed \
     $USER@host.docker.internal:$(pwd)/inv.xml,fdsnxml
-    # for a fdsnxml inventory format.
 
-#. (Optional) Check the data stream::
+
+#. (Optional) Check the data stream from another terminal::
     
     slinktool -Q localhost:18022 
     scrttv -I slink://localhost:18022 
@@ -101,8 +136,3 @@ Usage
     scolv -I file://data.mseed \
     -d sqlite3://event_db.sqlite  \
     --offline --debug
-
-.. note::
-
-    This is a placeholder
-

--- a/doc/templates/apps.rst
+++ b/doc/templates/apps.rst
@@ -31,3 +31,12 @@ Utilities
    /apps/scgof
    /apps/sceewdump
 
+=========
+Tutorials
+=========
+
+.. toctree::
+   :maxdepth: 3
+   
+   /base/tuto-playbacks
+


### PR DESCRIPTION
- Create a Tutorial section and add a playback tutorial with scpbd/FinDer dockers
- Include an example with the Elm M4.3 mainshock data
- In finder setup doc: add a global config example with slink connection to host 
  
@FMassin  and  @maboese FYI  
