### PR TITLE
[scfinder] Applies white and black lists in Finder::Init and to the logging of station coordinates in the debug log channel

### DIFF
--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -490,18 +490,29 @@ class App : public Client::StreamApplication {
 						SensorLocation *loc = sta->sensorLocation(l);
 						if ( loc->start() > refTime ) continue;
 						try { if ( loc->end() <= refTime ) continue; }
-						catch ( ... ) {}
+							catch ( ... ) {}
 
-						try {
-							station_coord_list.push_back(Coordinate(loc->latitude(), loc->longitude()));
-							SEISCOMP_DEBUG("+ %s.%s.%s  %f  %f",
-							               net->code().c_str(), sta->code().c_str(),
-						                   loc->code().c_str(), loc->latitude(), loc->longitude());
-						}
-						catch ( std::exception &e ) {
-							SEISCOMP_WARNING("%s.%s: location '%s': failed to add coordinate: %s",
-							                 net->code().c_str(), sta->code().c_str(),
-							                 loc->code().c_str(), e.what());
+						for ( size_t c = 0; c < loc->streamCount(); ++c ) {
+							Stream *cha = loc->stream(c);
+							if ( cha->start() > refTime ) continue;
+							try { if ( cha->end() <= refTime ) continue; }
+							catch ( ... ) {}
+
+							std::string sid = net->code() + "." + sta->code() + "." + loc->code() + "." + cha->code();
+							if ( !_eewProc.isStreamIDAllowed(sid) ) continue;
+
+							try {
+								station_coord_list.push_back(Coordinate(loc->latitude(), loc->longitude()));
+								SEISCOMP_DEBUG("+ %s.%s.%s  %f  %f",
+											net->code().c_str(), sta->code().c_str(),
+											loc->code().c_str(), loc->latitude(), loc->longitude());
+							}
+							catch ( std::exception &e ) {
+								SEISCOMP_WARNING("%s.%s: location '%s': failed to add coordinate: %s",
+												net->code().c_str(), sta->code().c_str(),
+												loc->code().c_str(), e.what());
+							}
+							break;
 						}
 					}
 				}

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -506,13 +506,13 @@ class App : public Client::StreamApplication {
 								SEISCOMP_DEBUG("+ %s.%s.%s  %f  %f",
 											net->code().c_str(), sta->code().c_str(),
 											loc->code().c_str(), loc->latitude(), loc->longitude());
+								break;
 							}
 							catch ( std::exception &e ) {
 								SEISCOMP_WARNING("%s.%s: location '%s': failed to add coordinate: %s",
 												net->code().c_str(), sta->code().c_str(),
 												loc->code().c_str(), e.what());
 							}
-							break;
 						}
 					}
 				}


### PR DESCRIPTION
The [black and white lists are applied](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/blob/befb54b69179deb8e27ed48dab23736d149870fa/libs/seiscomp/processing/eewamps/processor.cpp#L374) when the envelope processor subscribes to the channel inventory.

In scfinder [channel subscription in the envelope processor instantiation](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/blob/befb54b69179deb8e27ed48dab23736d149870fa/apps/eew/scfinder/main.cpp#L449) was independent from the [list of stations provided to Finder::Init](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/blob/befb54b69179deb8e27ed48dab23736d149870fa/apps/eew/scfinder/main.cpp#L512) (made without considering the white and black lists). 

This PR simply adds the exact same black and white list check made in envelope processor to the list of stations provided to Finder::Init. This should make sure all the lists of stations shown in the log is consistent with the user config.

> **_This PR introduces a minor change in scfinder workflow_:** Before this PR the Finder instance in scfinder was still initialized with all the blacklisted stations, and the blacklist would just _mute_ some of them! The mask would limit the interpolation, but not the content of FinDer's internal data lists! A FinDer expert (@maboese, @jenrandrews) should make sure initializing Finder without blacklisted station has _only_ positive effect...

## Testing
The debug log lines of format :
```bash
 [debug] + %s.%s.%s.%s
```
should now be exactly consistent with the next set of debug lines of format:
```bash
 [debug] + %s.%s.%s %f %f
```
The later would still include blacklisted stations without this PR.

## Review  
🙏 Please make sure you agree @jenrandrews, @maboese & @Thom-P  

---

Thank you!  

_Fred_  
