### PR TITLE
[scfinder] Add option for computing the mask.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+* scfinder:
+   
+  * [#77](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/pull/77): Add option for computing the mask.
+
 ## tag 5.1.1.2025
 
 * Fix event data in unit test.  

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -243,6 +243,13 @@
 						End time of data acquisition time window, requires also --ts
 					</description>
 				</option>
+				<option long-flag="calculate-mask">
+					<description>
+						Calculate FinDer mask according to scfinder configuration (i.e.,
+						FinDer "MASK_STATION_DISTANCE" and scfinder "streams.whitelist" 
+						and "streams.blacklist"), output in specified path, and exit.
+					</description>
+				</option>
 			</group>
 		</command-line>
 	</module>

--- a/apps/eew/scfinder/descriptions/scfinder.xml
+++ b/apps/eew/scfinder/descriptions/scfinder.xml
@@ -246,8 +246,9 @@
 				<option long-flag="calculate-mask">
 					<description>
 						Calculate FinDer mask according to scfinder configuration (i.e.,
-						FinDer "MASK_STATION_DISTANCE" and scfinder "streams.whitelist" 
-						and "streams.blacklist"), output in specified path, and exit.
+						FinDer "MASK_STATION_DISTANCE", FinDer template resolution "D_KM" 
+						as well as scfinder "streams.whitelist" and "streams.blacklist"), 
+						output in specified path, and exit.
 					</description>
 				</option>
 			</group>


### PR DESCRIPTION
With the new option `--calculate-mask` in scfinder does now the following (via method initFinder) :
- initialises envelope (applies streams black and white lists)
- initialises FinDer processing (sets max station distance and template resolution according to provided FinDer config)
- runs [Finder::calculate_and_save_mask](https://github.com/SED-EEW/FinDer/blob/0cb20553a4ec311a87bd88655d8821847b8ca546/libsrc/finder_initialize.cc#L273) via [Finder::Create_New_Mask](https://github.com/SED-EEW/FinDer/blob/0cb20553a4ec311a87bd88655d8821847b8ca546/libsrc/finder_internal.cc#L235),
- Exit (successfully).

## Testing
A new mask should be created in `/tmp/mask.nc` when running:
```bash
scfinder --calculate-mask /tmp/mask.nc --debug --offline --inventory-db file:///usr/local/src/seiscomp/src/base/sed-addons/test/vs/inventory.xml        
```

## Review  
🙏 Please make sure it is correct @jenrandrews and @maboese and please test @Thom-P 

---

Thank you!  

_Fred_  
