### PR TITLE
[sceewlog] change default report directory to ESE_reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * sceewlog
 
-   * [#89] Change default report dir from VS_report to ESE_reports
+   * [#89] Change default report dir from VS_reports to ESE_reports
 
    * [#87] Update latest_event initial value to comply with seiscomp 7 API and avoid crash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Master
 
 * sceewlog
+
+   * [#89] Change default report dir from VS_report to ESE_reports
+
    * [#87] Update latest_event initial value to comply with seiscomp 7 API and avoid crash
 
 * Documentation:

--- a/apps/eew/sceewlog/config/sceewlog.cfg
+++ b/apps/eew/sceewlog/config/sceewlog.cfg
@@ -56,7 +56,7 @@ report.activate=true
 report.eventbuffer=600
 
 # Directory to save reports to. 
-report.directory=@LOGDIR@/VS_reports
+report.directory=@LOGDIR@/ESE_reports
 
 #ActiveMQ - enable or disable
 ActiveMQ.activate = true

--- a/apps/eew/sceewlog/descriptions/sceewlog.xml
+++ b/apps/eew/sceewlog/descriptions/sceewlog.xml
@@ -130,7 +130,7 @@
 					Time in seconds that events and the related objects are buffered.
 					</description>
 				</parameter>
-				<parameter name="directory" type="dir" default="~/.seiscomp/log/EEW_reports">
+				<parameter name="directory" type="dir" default="~/.seiscomp/log/ESE_reports">
 					<description>
 					Directory to save reports to.
 					</description>

--- a/apps/eew/sceewlog/sceewlog.py
+++ b/apps/eew/sceewlog/sceewlog.py
@@ -54,7 +54,7 @@ class Listener(seiscomp.client.Application):
         self.report_head = "                                                                   |#St.   |                                                              \n"
         self.report_head += "Tdiff |Type|Mag.|Lat.  |Lon.   |Depth |origin time (UTC)      |Lik.|Or.|Ma.|Str.|Len. |Author   |Creation t.            |Tdiff(current o.)\n"
         self.report_head += "-"*int(len(self.report_head)/2-1) + "\n"
-        self.report_directory = os.path.join(self.ei.logDir(), 'EEW_reports')
+        self.report_directory = os.path.join(self.ei.logDir(), 'ESE_reports')
         # email settings
         self.sendemail = True
         self.smtp_server = None


### PR DESCRIPTION
Change the default report directory from VS_reports to ESE_reports. This reflects the dual VS + FinDer possible solutions and help us communicate that our packages do not reduce to VS only.

The change is done:
 - In the default config file
 - In the XML description of the config
 - In the hardcoded init() section of sceewlog

And CHANGELOG is updated.

FYI @maboese and @FMassin 
