### PR TITLE
[sceewenv] get inventory reference time from --ts option

### DIFF
--- a/apps/eew/sceewenv/main.cpp
+++ b/apps/eew/sceewenv/main.cpp
@@ -169,7 +169,10 @@ class App : public Client::StreamApplication {
 			if ( _startTime.valid() ) recordStream()->setStartTime(_startTime);
 			if ( _endTime.valid() ) recordStream()->setEndTime(_endTime);
 
-			_eewProc.subscribeToChannels(recordStream(), Core::Time::GMT());
+			if ( _startTime.valid() )
+				_eewProc.subscribeToChannels(recordStream(), _startTime);
+			else
+				_eewProc.subscribeToChannels(recordStream(), Core::Time::GMT());
 
 			// We do not need lookup objects by publicID
 			DataModel::PublicObject::SetRegistrationEnabled(false);

--- a/apps/eew/sceewenv/main.cpp
+++ b/apps/eew/sceewenv/main.cpp
@@ -117,6 +117,12 @@ class App : public Client::StreamApplication {
 				}
 			}
 
+			if ( !_dumpEnvelope.empty() && _dumpEnvelope != "disp" && 
+			     _dumpEnvelope != "vel" && _dumpEnvelope != "acc" ) {
+				cerr << "Invalid argument for --dump-envelope option" << endl;
+				return false;
+			}
+
 			if ( !isInventoryDatabaseEnabled() )
 				setDatabaseEnabled(false, false);
 


### PR DESCRIPTION
@Thom-P this fixes the `--ts/--te` options used to create envelopes from historical data.

In the current implementation, the streams used by `sceewenv` are derived from the stations **currently** active in the inventory. With this PR, however, the reference time used to determine which streams should be added is taken from the start time specified with the `--ts` option, which allows to properly determine the stations active at the requested time.