### PR TITLE
[scfinder] comply with seiscomp 7 / API 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
    * [#86] Update finder playback image tag to "latest" and warn against config overrides.
 
 * scfinder:
+
+  * [#91] Make Seiscomp 7 compatible
    
   * [#77](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/pull/77): Add option for computing the mask.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * scfinder:
 
-  * [#91] Make Seiscomp 7 compatible
+  * [#93] Make Seiscomp 7 compatible
    
   * [#77](https://github.com/SED-EEW/SED-EEW-SeisComP-contributions/pull/77): Add option for computing the mask.
 

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -77,7 +77,7 @@ class StdoutOutput : public Logging::Output {
 	public:
 		StdoutOutput() {}
 #if SC_API_VERSION >= SC_API_VERSION_CHECK(17, 0, 0)
-		bool setup(const Util::Url &url) {}
+		bool setup(const Util::Url &url) override { (void)url; return true; }
 #endif
 	protected:
 		void log(const char */*channelName*/,

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -76,14 +76,20 @@ namespace {
 class StdoutOutput : public Logging::Output {
 	public:
 		StdoutOutput() {}
+#if SC_API_VERSION >= SC_API_VERSION_CHECK(17, 0, 0)
 		bool setup(const Util::Url &url) {}
-
+#endif
 	protected:
 		void log(const char */*channelName*/,
 		         Logging::LogLevel /*level*/,
 		         const char* msg,
-		         time_t /*time*/,
-			 uint32_t /*microseconds*/) {
+#if SC_API_VERSION >= SC_API_VERSION_CHECK(17, 0, 0)
+				 time_t /*time*/,
+				 uint32_t /*microseconds*/)
+#else
+				 time_t /*time*/)
+#endif
+		{
 			cout << msg << endl;
 		}
 };

--- a/apps/eew/scfinder/main.cpp
+++ b/apps/eew/scfinder/main.cpp
@@ -76,12 +76,14 @@ namespace {
 class StdoutOutput : public Logging::Output {
 	public:
 		StdoutOutput() {}
+		bool setup(const Util::Url &url) {}
 
 	protected:
 		void log(const char */*channelName*/,
 		         Logging::LogLevel /*level*/,
 		         const char* msg,
-		         time_t /*time*/) {
+		         time_t /*time*/,
+			 uint32_t /*microseconds*/) {
 			cout << msg << endl;
 		}
 };
@@ -789,7 +791,7 @@ class App : public Client::StreamApplication {
 
 				/* checks whether the timestamp of the last element in the pgas vector 
 				falls within the previous 15 seconds, continuing the loop if true */
-				if ( ( it->second->pgas.back().timestamp.seconds() ) < ( _referenceTime.seconds() - _finderMaxEnvelopeBufferDelay ) ) {
+				if ( ( it->second->pgas.back().timestamp.seconds() ) < ( _referenceTime.seconds() - _finderMaxEnvelopeBufferDelay.length() ) ) {
 					std::cout << "Instrument skipped \t PGA buffer starts (iso,s)\t PGA buffer end (iso,s)\t Reference time (iso,s)" << std::endl;
 					std::cout << it->first << "\t" << it->second->pgas.front().timestamp.iso() << "\t" << it->second->pgas.back().timestamp.iso() << "\t" << _referenceTime.iso() << std::endl;
 					std::cout << it->first << "\t" << it->second->pgas.front().timestamp.seconds() << "\t" << it->second->pgas.back().timestamp.seconds() <<  "\t" << _referenceTime.seconds() << std::endl;
@@ -801,7 +803,7 @@ class App : public Client::StreamApplication {
 					SEISCOMP_DEBUG("[%s] Instrument clipped and skipped", mseedid.c_str());
 					continue;
 				}
-				if ( ( it->second->maxPGA.lastclipped.seconds() ) >= ( _referenceTime.seconds() - _finderClipTimeout ) ) {
+				if ( ( it->second->maxPGA.lastclipped.seconds() ) >= ( _referenceTime.seconds() - _finderClipTimeout.length() ) ) {
 					SEISCOMP_DEBUG("[%s] Instrument clipped recently and skipped", mseedid.c_str());
 					continue;
 				}	
@@ -814,7 +816,7 @@ class App : public Client::StreamApplication {
 						it->second->meta->code().empty()?"--":it->second->meta->code().c_str(),
 						Coordinate(it->second->meta->latitude(), it->second->meta->longitude()),
 						it->second->maxPGA.value*100, 
-						it->second->maxPGA.timestamp
+						static_cast<double>(it->second->maxPGA.timestamp)
 					)
 				);
 
@@ -884,7 +886,7 @@ class App : public Client::StreamApplication {
 				// some method for getting the timestamp associated with the data
 				// event_continue == false when we want to stop processing
 				try {
-					(*fit)->process(tick, _latestMaxPGAs);
+					(*fit)->process(static_cast<double>(tick), _latestMaxPGAs);
 				}
 				catch ( FiniteFault::Error &e ) {
 					SEISCOMP_ERROR("Exception from FinDer::process: %s", e.what());
@@ -913,7 +915,7 @@ class App : public Client::StreamApplication {
 				_bufVarLen = _bufDefaultLen;
 			} else {
 				double rup2time = 1.5;
-				if (maxRupLen > _bufVarLen * rup2time) {
+				if (maxRupLen > _bufVarLen.length() * rup2time) {
 					double tmp = maxRupLen / rup2time;
 					_bufVarLen = min((long)tmp, _bufferLength.seconds());
 					SEISCOMP_DEBUG("Increasing data window to %ld because of active FinDer event rupture length %.1f", 


### PR DESCRIPTION
Fix compiling of scfinder with Seiscomp 7 and remain backward compatible with Seiscomp 6

* Update prototype of Logging::Output
* Explicitly call length of TimeSpan objects
* Explicitly cast Time objects to double   
* Update changelog